### PR TITLE
Add Phase 0 data lake specs and schemas

### DIFF
--- a/docs/specs/catalog_schema.sql
+++ b/docs/specs/catalog_schema.sql
@@ -1,0 +1,31 @@
+-- Catálogo mínimo (SQLite/DuckDB) para indexar el lake
+CREATE TABLE IF NOT EXISTS files (
+  id INTEGER PRIMARY KEY,
+  source TEXT NOT NULL,
+  market TEXT NOT NULL,
+  timeframe TEXT NOT NULL,
+  symbol TEXT NOT NULL,
+  year INT NOT NULL,
+  month INT NOT NULL,
+  path TEXT NOT NULL,
+  ts_min TIMESTAMP,
+  ts_max TIMESTAMP,
+  rows BIGINT,
+  compression TEXT,
+  version TEXT,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS levels_daily (
+  id INTEGER PRIMARY KEY,
+  market TEXT NOT NULL,
+  symbol TEXT NOT NULL,
+  year INT NOT NULL,
+  month INT NOT NULL,
+  path TEXT NOT NULL,
+  date_min DATE,
+  date_max DATE,
+  rows INT,
+  version TEXT,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/docs/specs/partitioning.md
+++ b/docs/specs/partitioning.md
@@ -1,0 +1,11 @@
+# Particionado del Data Lake
+
+Ruta base (ejemplo cripto IBKR):
+```
+data/source=ibkr/market=crypto/timeframe=<TF>/symbol=<SYMBOL>/year=<YYYY>/month=<MM>/part-<YYYY>-<MM>.parquet
+```
+- **TF**: M1 (canónico), M5, M15, H1, D1 (agregados offline).
+- **SYMBOL**: `BASE-QUOTE` (p. ej., `BTC-USD`).
+- **Archivo mensual** con **row groups ~diarios**. Evita “archivo por día” salvo casos especiales.
+- **Compresión**: ZSTD (preferida) o Snappy.
+- **Semántica**: `ts` en UTC, **bar_end**.

--- a/docs/specs/schema_levels_daily.parquet.json
+++ b/docs/specs/schema_levels_daily.parquet.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Schema Niveles Diarios (estrecho)",
+  "type": "object",
+  "properties": {
+    "session_date": {"type": "string", "format": "date"},
+    "pdh": {"type": "number"},
+    "pdl": {"type": "number"},
+    "pdc": {"type": "number"},
+    "or_start_utc": {"type": "string", "format": "date-time"},
+    "or_end_utc": {"type": "string", "format": "date-time"},
+    "orh": {"type": "number"},
+    "orl": {"type": "number"},
+    "tz": {"type": "string"},
+    "or_profile_key": {"type": "string"},
+    "symbol": {"type": "string"},
+    "market": {"type": "string", "enum": ["crypto"]}
+  },
+  "required": ["session_date"],
+  "additionalProperties": true
+}

--- a/docs/specs/schema_m1.parquet.json
+++ b/docs/specs/schema_m1.parquet.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Schema M1 OHLCV (Crypto)",
+  "type": "object",
+  "properties": {
+    "ts": {"type": "string", "format": "date-time", "description": "UTC bar_end timestamp"},
+    "open": {"type": "number"},
+    "high": {"type": "number"},
+    "low": {"type": "number"},
+    "close": {"type": "number"},
+    "volume": {"type": "integer"},
+    "source": {"type": "string", "enum": ["ibkr"]},
+    "market": {"type": "string", "enum": ["crypto"]},
+    "symbol": {"type": "string"},
+    "exchange": {"type": "string"},
+    "what_to_show": {"type": "string", "enum": ["AGGTRADES"]}
+  },
+  "required": ["ts", "open", "high", "low", "close", "volume"],
+  "additionalProperties": true
+}

--- a/src/datalake/specs.py
+++ b/src/datalake/specs.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+from pydantic import BaseModel, Field
+from typing import Literal
+
+class ParquetOptions(BaseModel):
+    compression: Literal["ZSTD", "SNAPPY"] = "ZSTD"
+    bar_semantics: Literal["bar_end", "bar_start"] = "bar_end"
+    timezone: str = "UTC"
+
+class DatasetDescriptor(BaseModel):
+    source: str = "ibkr"
+    market: str = "crypto"
+    timeframe: str = "M1"
+    symbol: str = "BTC-USD"
+    year: int = 2025
+    month: int = 8
+    path: str = "data/source=ibkr/market=crypto/timeframe=M1/symbol=BTC-USD/year=2025/month=08/part-2025-08.parquet"
+    parquet: ParquetOptions = Field(default_factory=ParquetOptions)


### PR DESCRIPTION
## Summary
- add partitioning guidelines
- define parquet schemas and catalog SQL
- include Pydantic models for parquet and dataset descriptors

## Testing
- `pytest`
- `python -m py_compile src/datalake/specs.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2180862f08324a9d37214caf4fe2d