### PR TITLE
feat: add crypto liquidity profiles

### DIFF
--- a/docs/specs/liquidity.md
+++ b/docs/specs/liquidity.md
@@ -1,0 +1,12 @@
+# Perfiles de liquidez (Crypto)
+
+Perfiles recomendados para construir **OR** en cripto:
+
+- `daily_open_utc`: tz=`UTC`, start=`00:00`, minutes=5 — coherente 24/7.
+- `us_equity_open`: tz=`America/New_York`, start=`09:30`, minutes=5 — captura flujo USA.
+- `asia_open`: tz=`Asia/Tokyo`, start=`09:00`, minutes=5.
+
+## Reglas anti-look-ahead
+- `ORH/ORL` del día D **solo** se usan **después** de `or_end_utc`.
+- `PDH/PDL/PDC` del día D-1 se aplican a todo el día D.
+- `ts` es UTC con semántica **bar_end** (evita ambigüedad de pertenencia a OR).

--- a/src/datalake/liquidity_profiles.py
+++ b/src/datalake/liquidity_profiles.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+LIQUIDITY_PROFILES_CRYPTO = {
+    "daily_open_utc":   {"tz": "UTC",                "start": "00:00", "minutes": 5},
+    "us_equity_open":   {"tz": "America/New_York",   "start": "09:30", "minutes": 5},
+    "asia_open":        {"tz": "Asia/Tokyo",         "start": "09:00", "minutes": 5}
+}
+
+DEFAULT_CRYPTO_PROFILE = "us_equity_open"


### PR DESCRIPTION
## Summary
- document recommended crypto opening range profiles and anti-look-ahead rules
- add python module defining crypto liquidity profiles and default profile

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c218a11b7c8324b7b47908833ad286