### PR TITLE
Add environment configuration and contribution guide

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Raíz del data lake (ruta absoluta o relativa)
+DATA_LAKE_ROOT=./
+# Formato de almacenamiento
+DATALAKE_FORMAT=parquet
+PARQUET_COMPRESSION=ZSTD
+BAR_SEMANTICS=bar_end
+DEFAULT_TIMEZONE=UTC
+# Catálogo (opcional)
+CATALOG_DB=./catalog.sqlite
+# Perfil de OR para CRYPTO
+CRYPTO_OR_PROFILE=us_equity_open

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,4 @@
+# Contribuir
+- No subir datos binarios al repo.
+- Mantener specs y contratos estables; cambios mayores con versionado.
+- Ejecutar validadores antes de abrir PR.

--- a/src/datalake/config.py
+++ b/src/datalake/config.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+import os
+from dataclasses import dataclass
+from dotenv import load_dotenv
+
+load_dotenv(override=True)
+
+@dataclass
+class LakeConfig:
+    root: str = os.getenv("DATA_LAKE_ROOT", "./")
+    format: str = os.getenv("DATALAKE_FORMAT", "parquet").lower()
+    compression: str = os.getenv("PARQUET_COMPRESSION", "ZSTD").upper()
+    bar_semantics: str = os.getenv("BAR_SEMANTICS", "bar_end")
+    default_tz: str = os.getenv("DEFAULT_TIMEZONE", "UTC")
+    catalog_db: str = os.getenv("CATALOG_DB", "./catalog.sqlite")
+    crypto_or_profile: str = os.getenv("CRYPTO_OR_PROFILE", "us_equity_open")


### PR DESCRIPTION
## Summary
- provide `.env.example` with core lake settings
- add `LakeConfig` dataclass to load environment variables with defaults
- document repository contribution guidelines

## Testing
- `python -m py_compile src/datalake/config.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c219a3db6c8324b9342bd1bffc4214