### PR TITLE
feat: add layout validator and smoke CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: ci
+on: [push, pull_request]
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: python -m pip install -U pip
+      - run: pip install -r requirements.txt pytest
+      - run: PYTHONPATH=src pytest -q
+      - run: PYTHONPATH=src python -c "from datalake.config import LakeConfig; print(LakeConfig())"
+      - run: PYTHONPATH=src python src/datalake/validate_layout.py || true

--- a/src/datalake/validate_layout.py
+++ b/src/datalake/validate_layout.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+import os, re
+from pathlib import Path
+from rich import print
+from datalake.config import LakeConfig
+
+LAYOUT_RE = re.compile(
+    r"^data/source=([^/]+)/market=([^/]+)/timeframe=([^/]+)/symbol=([^/]+)/"
+    r"year=([0-9]{4})/month=([0-9]{2})/part-\\5-\\6\\.parquet$"
+)
+
+def main() -> int:
+    cfg = LakeConfig()
+    root = Path(cfg.root).resolve()
+    data_dir = root / "data"
+    if not data_dir.exists():
+        print("[yellow]No hay carpeta 'data' aún. (OK en Fase 0)[/yellow]")
+        return 0
+    errors = 0
+    for p in data_dir.rglob("*.parquet"):
+        rel = p.relative_to(root).as_posix()
+        if not LAYOUT_RE.match(rel):
+            errors += 1
+            print(f"[red]Layout inválido:[/red] {rel}")
+    if errors:
+        print(f"[red]Archivos fuera de estándar: {errors}[/red]")
+        return 2
+    print("[green]Layout OK[/green]")
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_specs_smoke.py
+++ b/tests/test_specs_smoke.py
@@ -1,0 +1,14 @@
+import json, pathlib
+
+def test_schema_files_exist():
+    for name in [
+        'docs/specs/schema_m1.parquet.json',
+        'docs/specs/schema_levels_daily.parquet.json',
+        'docs/specs/partitioning.md'
+    ]:
+        assert pathlib.Path(name).exists()
+
+def test_schema_m1_json_valid():
+    p = pathlib.Path('docs/specs/schema_m1.parquet.json')
+    d = json.loads(p.read_text())
+    assert d['properties']['ts']['description'].startswith('UTC')


### PR DESCRIPTION
## Summary
- add minimal layout validator
- smoke-test docs specs and config in CI

## Testing
- `PYTHONPATH=src pytest -q`
- `PYTHONPATH=src python -c 'from datalake.config import LakeConfig; print(LakeConfig())'`
- `PYTHONPATH=src python src/datalake/validate_layout.py || true`


------
https://chatgpt.com/codex/tasks/task_e_68c21aa62238832488aec65d89a0f4b3