### PR TITLE
feat(ingestors): bridge de submódulo y wrapper de contratos cripto IB

### DIFF
--- a/src/datalake/ingestors/ibkr/contracts.py
+++ b/src/datalake/ingestors/ibkr/contracts.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+from typing import Tuple
+from datalake.ingestors.ibkr.submodule_bridge import ensure_submodule_on_syspath
+
+ensure_submodule_on_syspath()
+
+try:
+    # Reuso directo del submódulo (sin tocarlo)
+    from config.crypto_symbols import CRYPTO_SYMBOLS, IB_CRYPTO_EX, DEFAULT_CRYPTO  # type: ignore
+except Exception as e:
+    raise ImportError(f"No se pudo importar config.crypto_symbols desde submódulo: {e}")
+
+try:
+    from ib_insync import Contract  # lightweight import aquí
+except Exception as e:
+    raise ImportError(f"Falta dependencia ib_insync en el entorno: {e}")
+
+
+def split_symbol(symbol: str) -> Tuple[str, str]:
+    """Convierte 'BTC-USD' o 'BTCUSD' en ('BTC','USD')."""
+    s = symbol.replace(':', '-').replace('/', '-').upper()
+    if '-' in s:
+        base, quote = s.split('-', 1)
+    else:
+        # heurística simple para 3/4 letras de quote comunes
+        if s.endswith('USDT'):
+            base, quote = s[:-4], 'USDT'
+        elif s.endswith('USD'):
+            base, quote = s[:-3], 'USD'
+        else:
+            raise ValueError(f"No puedo inferir quote en símbolo: {symbol}")
+    return base, quote
+
+
+def make_crypto_contract(symbol: str, exchange: str | None = None) -> Contract:
+    """Construye Contract CRYPTO para IB reutilizando el mapeo del submódulo.
+    - symbol: 'BTC-USD', 'ETH-USD', etc.
+    - exchange: si no se pasa, usa IB_CRYPTO_EX.get(base, 'PAXOS').
+    """
+    base, quote = split_symbol(symbol)
+    # valida contra CRYPTO_SYMBOLS del submódulo si está disponible
+    if CRYPTO_SYMBOLS and base not in CRYPTO_SYMBOLS:
+        # permitir símbolos nuevos, pero avisar
+        pass
+    ex = exchange or IB_CRYPTO_EX.get(base, 'PAXOS')
+    c = Contract()
+    c.secType = 'CRYPTO'
+    c.symbol = base
+    c.currency = quote
+    c.exchange = ex
+    return c

--- a/src/datalake/ingestors/ibkr/submodule_bridge.py
+++ b/src/datalake/ingestors/ibkr/submodule_bridge.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+"""Bridge para importar módulos desde vendor/backtest_crew sin tocar el original.
+Uso:
+    from datalake.ingestors.ibkr.submodule_bridge import ensure_submodule_on_syspath
+    ensure_submodule_on_syspath()
+    from config.crypto_symbols import CRYPTO_SYMBOLS
+"""
+from __future__ import annotations
+import sys
+from pathlib import Path
+
+_ADDED = False
+
+def ensure_submodule_on_syspath() -> None:
+    """Inserta vendor/backtest_crew en sys.path si no existe ya."""
+    global _ADDED
+    if _ADDED:
+        return
+    here = Path(__file__).resolve()
+    # .../backtest_crew-datalake/src/datalake/ingestors/ibkr/submodule_bridge.py
+    repo_root = here.parents[4]
+    sub = repo_root / 'vendor' / 'backtest_crew'
+    if not sub.exists():
+        raise RuntimeError("Submódulo vendor/backtest_crew no encontrado. Ejecuta 'git submodule update --init --recursive'.")
+    sub_path = str(sub)
+    if sub_path not in sys.path:
+        sys.path.insert(0, sub_path)
+    _ADDED = True

--- a/tests/test_bridge_smoke.py
+++ b/tests/test_bridge_smoke.py
@@ -1,0 +1,7 @@
+from datalake.ingestors.ibkr.submodule_bridge import ensure_submodule_on_syspath
+
+def test_bridge_imports():
+    ensure_submodule_on_syspath()
+    import importlib
+    m = importlib.import_module('config.crypto_symbols')
+    assert hasattr(m, 'CRYPTO_SYMBOLS')


### PR DESCRIPTION
## Summary
- add bridge to expose vendor/backtest_crew modules without modifying submodule
- add IBKR crypto contract helpers reusing config.crypto_symbols
- smoke test to ensure bridge can import submodule

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c22181aefc83248721c6cae45bc37b