### PR TITLE
vendor: import crypto symbols config from backtest_crew

### DIFF
--- a/vendor/backtest_crew/config/crypto_symbols.py
+++ b/vendor/backtest_crew/config/crypto_symbols.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+"""Símbolos por defecto para mercado de criptomonedas.
+Se pueden ampliar según disponibilidad en IB (PAXOS).
+"""
+import os
+
+CRYPTO_SYMBOLS = [
+    "BTC-USD",
+    "ETH-USD"
+]
+DEFAULT_CRYPTO = "BTC-USD"
+# Puedes cambiar el exchange por variable de entorno si fuera necesario
+IB_CRYPTO_EXCHANGE = os.getenv("IB_CRYPTO_EXCHANGE", "PAXOS")


### PR DESCRIPTION
## Summary
- vendor crypto market symbols config from backtest_crew repo

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c22eec07b08324bb04d0b31ddbe3e5