### PR TITLE
docs/ci/test: bridge docs + init submodules in CI + ignore vendor in pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - run: git submodule update --init --recursive || true
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'

--- a/README.md
+++ b/README.md
@@ -38,3 +38,14 @@ levels/
 - Fase 1: Ingesta offline M1 (BTC-USD, ETH-USD) y validación.
 - Fase 2: Agregados (M5/M15/H1/D1) y niveles diarios.
 - Fase 3: Capa de acceso (DuckDB→pandas / Polars) y contratos de lectura.
+
+
+## Reuso de código `backtest_crew`
+Este repo **reusa** módulos de `backtest_crew` ubicados bajo `vendor/backtest_crew` (como submódulo o snapshot). Para importarlos desde el código del datalake:
+
+```python
+from datalake.ingestors.ibkr.submodule_bridge import ensure_submodule_on_syspath
+ensure_submodule_on_syspath()
+from config.crypto_symbols import CRYPTO_SYMBOLS
+```
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = -q
+norecursedirs = vendor .venv data levels cache


### PR DESCRIPTION
## Summary
- document backtest_crew bridge usage in README
- init git submodules in CI pipeline
- configure pytest to skip vendor and other dirs

## Testing
- `pip install -r requirements.txt`
- `pytest` *(fails: ModuleNotFoundError: No module named 'datalake')*

------
https://chatgpt.com/codex/tasks/task_e_68c231d18824832483f722aebad65a1b