### PR TITLE
feat(ingest-m1): add crypto M1 fetcher and ingest CLI

### DIFF
--- a/src/datalake/ingestors/ibkr/contracts.py
+++ b/src/datalake/ingestors/ibkr/contracts.py
@@ -1,13 +1,18 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 from typing import Tuple
+import importlib
 from datalake.ingestors.ibkr.submodule_bridge import ensure_submodule_on_syspath
 
 ensure_submodule_on_syspath()
 
 try:
-    # Reuso directo del submódulo (sin tocarlo)
-    from config.crypto_symbols import CRYPTO_SYMBOLS, IB_CRYPTO_EX, DEFAULT_CRYPTO  # type: ignore
+    # Cargamos módulo de símbolos del submódulo vendor.
+    _cfg = importlib.import_module("config.crypto_symbols")
+    CRYPTO_SYMBOLS = getattr(_cfg, "CRYPTO_SYMBOLS", [])
+    DEFAULT_CRYPTO = getattr(_cfg, "DEFAULT_CRYPTO", "BTC-USD")
+    IB_CRYPTO_EX = getattr(_cfg, "IB_CRYPTO_EX", {})
+    DEFAULT_EXCHANGE = getattr(_cfg, "IB_CRYPTO_EXCHANGE", "PAXOS")
 except Exception as e:
     raise ImportError(f"No se pudo importar config.crypto_symbols desde submódulo: {e}")
 
@@ -43,7 +48,7 @@ def make_crypto_contract(symbol: str, exchange: str | None = None) -> Contract:
     if CRYPTO_SYMBOLS and base not in CRYPTO_SYMBOLS:
         # permitir símbolos nuevos, pero avisar
         pass
-    ex = exchange or IB_CRYPTO_EX.get(base, 'PAXOS')
+    ex = exchange or IB_CRYPTO_EX.get(base, DEFAULT_EXCHANGE)
     c = Contract()
     c.secType = 'CRYPTO'
     c.symbol = base

--- a/src/datalake/ingestors/ibkr/historical_fetcher.py
+++ b/src/datalake/ingestors/ibkr/historical_fetcher.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+import datetime as dt
+from typing import Iterable, List
+import pandas as pd
+from ib_insync import util
+from datalake.ingestors.ibkr.ib_client import IBClient, IBClientConfig
+from datalake.ingestors.ibkr.contracts import make_crypto_contract
+from datalake.ingestors.ibkr.normalize import to_bar_end_utc, enforce_m1_grid
+
+
+def _date_range_days(start: pd.Timestamp, end: pd.Timestamp) -> Iterable[pd.Timestamp]:
+    cur = start.normalize()
+    end = end.normalize()
+    while cur <= end:
+        yield cur
+        cur += pd.Timedelta(days=1)
+
+
+def fetch_crypto_m1_range(symbol: str, start_utc: str, end_utc: str, client_cfg: IBClientConfig | None = None) -> pd.DataFrame:
+    """Descarga histórico M1 (AGGTRADES) por ventanas diarias y concatena.
+    Retorna DataFrame con columnas: ts, open, high, low, close, volume, source, market, symbol, exchange, what_to_show.
+    """
+    cfg = client_cfg or IBClientConfig()
+    cli = IBClient(cfg)
+    cli.connect()
+    try:
+        contract = make_crypto_contract(symbol)
+        start = pd.Timestamp(start_utc, tz='UTC')
+        end = pd.Timestamp(end_utc, tz='UTC')
+        dfs: List[pd.DataFrame] = []
+        for day in _date_range_days(start, end):
+            cli._throttle()
+            # endDateTime debe ser fin del día UTC
+            end_dt = (day + pd.Timedelta(days=1) - pd.Timedelta(seconds=1)).to_pydatetime()
+            bars = cli.ib.reqHistoricalData(
+                contract,
+                endDateTime=end_dt,
+                durationStr='1 D',
+                barSizeSetting='1 min',
+                whatToShow='AGGTRADES',
+                useRTH=False,
+                formatDate=1,
+                keepUpToDate=False
+            )
+            df = util.df(bars)
+            if df.empty:
+                continue
+            df = to_bar_end_utc(df, 'date')
+            df = df.rename(columns={'open':'open','high':'high','low':'low','close':'close','volume':'volume'})
+            df['source'] = 'ibkr'
+            df['market'] = 'crypto'
+            df['symbol'] = symbol
+            df['exchange'] = contract.exchange
+            df['what_to_show'] = 'AGGTRADES'
+            dfs.append(df[['ts','open','high','low','close','volume','source','market','symbol','exchange','what_to_show']])
+        if not dfs:
+            return pd.DataFrame(columns=['ts','open','high','low','close','volume','source','market','symbol','exchange','what_to_show'])
+        out = enforce_m1_grid(pd.concat(dfs, ignore_index=True))
+        return out
+    finally:
+        cli.disconnect()

--- a/src/datalake/ingestors/ibkr/ingest_cli.py
+++ b/src/datalake/ingestors/ibkr/ingest_cli.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+import argparse
+import sys
+import pandas as pd
+from rich import print
+from datalake.config import LakeConfig
+from datalake.ingestors.ibkr.historical_fetcher import fetch_crypto_m1_range
+from datalake.ingestors.ibkr.writer import write_month
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description='Ingesta M1 cripto (AGGTRADES) → Parquet particionado')
+    ap.add_argument('--symbols', required=True, help='Lista separada por comas, p.ej. BTC-USD,ETH-USD')
+    ap.add_argument('--from', dest='date_from', required=True, help='Inicio UTC, p.ej. 2025-07-01')
+    ap.add_argument('--to', dest='date_to', required=True, help='Fin UTC, p.ej. 2025-08-31')
+    args = ap.parse_args(argv)
+
+    cfg = LakeConfig()
+    symbols = [s.strip() for s in args.symbols.split(',') if s.strip()]
+
+    for sym in symbols:
+        print(f"[bold]Ingestando[/bold] {sym} {args.date_from}→{args.date_to}")
+        df = fetch_crypto_m1_range(sym, args.date_from + ' 00:00:00Z', args.date_to + ' 23:59:59Z')
+        if df.empty:
+            print(f"[yellow]Sin datos para {sym}[/yellow]")
+            continue
+        # escribir por meses
+        df['year'] = pd.to_datetime(df['ts'], utc=True).dt.year
+        df['month'] = pd.to_datetime(df['ts'], utc=True).dt.month
+        for (y, m), chunk in df.groupby(['year','month']):
+            path = write_month(chunk.drop(columns=['year','month']), symbol=sym, cfg=cfg)
+            print(f"[green]OK[/green] {sym} → {path}")
+    return 0
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/test_contracts_and_norm.py
+++ b/tests/test_contracts_and_norm.py
@@ -1,0 +1,12 @@
+from datalake.ingestors.ibkr.contracts import split_symbol, make_crypto_contract
+from datalake.ingestors.ibkr.normalize import to_bar_end_utc
+import pandas as pd
+
+def test_split_symbol():
+    assert split_symbol('BTC-USD') == ('BTC','USD')
+    assert split_symbol('ETHUSD') == ('ETH','USD')
+
+def test_to_bar_end():
+    df = pd.DataFrame({'date':['2025-08-01T00:00:00Z','2025-08-01T00:01:00Z'], 'open':[1,2],'high':[1,2],'low':[1,2],'close':[1,2],'volume':[1,1]})
+    out = to_bar_end_utc(df)
+    assert str(out.loc[0,'ts']) == '2025-08-01 00:01:00+00:00'


### PR DESCRIPTION
## Summary
- add daily-windowed M1 AGGTRADES fetcher for IBKR crypto
- provide CLI to ingest symbol ranges to partitioned parquet
- add basic contract/normalization tests and import fixes

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c234ca66e08324b8a178101fdc8067