### PR TITLE
docs: add IBKR crypto M1 ingestion guide and README quickstart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,9 @@
 __pycache__/
 .venv/
 .env
+
+cache/
+data/
+*.tmp.parquet
+levels/
+*.parquet

--- a/README.md
+++ b/README.md
@@ -49,3 +49,18 @@ ensure_submodule_on_syspath()
 from config.crypto_symbols import CRYPTO_SYMBOLS
 ```
 
+
+
+## Fase 1 · Ingesta de Cripto (M1, IBKR)
+- Descarga de velas **M1** vía IBKR (`AGGTRADES`).
+- Persistencia en **Parquet ZSTD** con particionado `source/market/timeframe/symbol/year/month`.
+- **Timestamps** en UTC con semántica **bar_end**.
+
+### Quickstart
+```bash
+python -m venv .venv && source .venv/bin/activate   # Windows: .venv\Scripts\activate
+pip install -r requirements.txt
+python -m datalake.ingestors.ibkr.ingest_cli --symbols BTC-USD --from 2025-07-01 --to 2025-07-31
+```
+Más detalles en: [`docs/usage/ingest_crypto_m1.md`](docs/usage/ingest_crypto_m1.md)
+

--- a/docs/usage/ingest_crypto_m1.md
+++ b/docs/usage/ingest_crypto_m1.md
@@ -1,0 +1,79 @@
+# Fase 1 — Ingesta M1 de Cripto (IBKR → Parquet)
+
+Esta guía explica cómo descargar velas **M1** de criptomonedas desde **IBKR** (usando `AGGTRADES`) y guardarlas en el *data lake* como **Parquet ZSTD**, particionado por fuente/mercado/timeframe/símbolo/año/mes.
+
+## Prerrequisitos
+- **IB Gateway/TWS** ejecutándose (Paper o Live), mismo host por defecto `127.0.0.1:7497`.
+- Suscripción/permiso de *market data* de criptomonedas en IB.
+- Python 3.10+ y `pip install -r requirements.txt` (incluye `ib_insync`).
+- Código de reuso disponible bajo `vendor/backtest_crew` (submódulo o copia). Si usas submódulo:
+  ```bash
+  git submodule update --init --recursive
+  ```
+
+## Semántica de timestamps
+- Se usa **bar_end** en UTC: el `ts` de cada barra corresponde al **fin** del minuto.
+- Cripto es 24/7: días completos ≈ **1440** filas.
+
+## Quickstart
+```bash
+# 1) Crear entorno
+python -m venv .venv && source .venv/bin/activate    # Windows: .venv\\Scripts\\activate
+pip install -r requirements.txt
+
+# 2) (Opcional) Fijar raíz del data lake si quieres escribir fuera del repo
+# Linux/Mac
+export LAKE_ROOT=/mnt/datalake
+# Windows PowerShell
+# setx LAKE_ROOT "D:\\datalake"  ; reinicia la terminal para que aplique
+
+# 3) Ejecutar ingesta (ejemplos)
+python -m datalake.ingestors.ibkr.ingest_cli \
+  --symbols BTC-USD,ETH-USD \
+  --from 2025-07-01 --to 2025-07-31
+```
+
+## ¿Qué se genera?
+```
+<LAKE_ROOT || repo>/data/source=ibkr/market=crypto/timeframe=M1/
+└── symbol=BTC-USD/
+    └── year=2025/
+        └── month=07/
+            └── part-2025-07.parquet
+```
+Columnas: `ts` (UTC bar_end), `open`, `high`, `low`, `close`, `volume`, `source`, `market`, `symbol`, `exchange`, `what_to_show`.
+
+## Verificación rápida
+```bash
+python - << 'PY'
+import pandas as pd
+p = 'data/source=ibkr/market=crypto/timeframe=M1/symbol=BTC-USD/year=2025/month=07/part-2025-07.parquet'
+df = pd.read_parquet(p)
+print(df.ts.min(), df.ts.max(), len(df))
+print(df.head())
+PY
+```
+
+## Opciones del CLI
+```
+python -m datalake.ingestors.ibkr.ingest_cli --help
+  --symbols    Lista separada por comas (BTC-USD,ETH-USD,...)
+  --from       Inicio (UTC, YYYY-MM-DD)
+  --to         Fin (UTC, YYYY-MM-DD)
+```
+> El *rate limit* por defecto es ~0.7 req/s y se gestiona internamente para respetar el pacing de IB.
+
+## Problemas comunes (troubleshooting)
+- **Error 10299 (AGGTRADES)**: asegúrate de no usar `TRADES`. El ingestor usa `whatToShow='AGGTRADES'`.
+- **Timeout/Cancelación en connect**: comprueba IB Gateway/TWS en `127.0.0.1:7497` y que el `clientId` no esté en uso.
+- **Sin datos**: revisa suscripción de mercado cripto, rango de fechas y símbolo (`BTC-USD`, `ETH-USD`).
+- **Archivos no aparecen**: valida `LAKE_ROOT` (si no está, se usa la raíz del repo).
+
+## Rendimiento y diseño
+- Escritura **mensual** por símbolo (ZSTD), idempotente: si reingestas, se fusiona y deduplica por `ts`.
+- Layout particionado facilita cargas en motores analíticos y *pruning* por año/mes.
+- Para ingestiones grandes, paraleliza **por símbolo** (cada proceso usa su propio `clientId`).
+
+## Próximos pasos (Fase 2)
+- Construcción de agregados (M5/M15/H1/D1).
+- Derivados de niveles/Break & Retest para orquestación B&R.


### PR DESCRIPTION
## Summary
- document Phase 1 crypto M1 ingestion workflow
- include quickstart and timestamp semantics in README
- ignore local data/cache directories in git

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2387b0ccc8324b1e8b93b62fb04ea