### PR TITLE
test: set pythonpath=src and ignore heavy dirs

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 addopts = -q
-norecursedirs = vendor .venv data levels cache
+pythonpath = src
+norecursedirs = vendor .venv data aggregates levels


### PR DESCRIPTION
## Summary
- configure pytest to locate packages in `src/`
- skip heavy directories in pytest discovery

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2e0fd7d4c8324b78770ceab8550f5