### PR TITLE
docs+tests(phase2): guía de uso y smoke tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ cache/
 data/
 *.tmp.parquet
 *.parquet
+
+levels/
+aggregates/

--- a/README.md
+++ b/README.md
@@ -64,3 +64,8 @@ python -m datalake.ingestors.ibkr.ingest_cli --symbols BTC-USD --from 2025-07-01
 ```
 Más detalles en: [`docs/usage/ingest_crypto_m1.md`](docs/usage/ingest_crypto_m1.md)
 
+
+
+## Fase 2 · Agregados & Niveles (B&R)
+Ver guía: [`docs/usage/phase2_aggregates_levels.md`](docs/usage/phase2_aggregates_levels.md)
+

--- a/docs/usage/phase2_aggregates_levels.md
+++ b/docs/usage/phase2_aggregates_levels.md
@@ -1,0 +1,13 @@
+# Fase 2 — Agregados (M5/M15/H1/D1) y Niveles OR (B&R)
+
+## Agregados
+```bash
+python -m datalake.aggregates.cli --symbols BTC-USD,ETH-USD --from 2025-07-01 --to 2025-07-31 --tfs M5,M15,H1,D1
+```
+Salida: `aggregates/source=ibkr/market=crypto/timeframe=<TF>/symbol=<SYM>/year=YYYY/month=MM/part-YYYY-MM.parquet`
+
+## Niveles OR
+```bash
+python -m datalake.levels.cli --symbols BTC-USD --from 2025-07-01 --to 2025-07-31 --or-window 00:00-01:00 --tz UTC
+```
+Salida: `levels/market=crypto/symbol=<SYM>/year=YYYY/part-YYYY.parquet`

--- a/tests/test_phase2_smoke.py
+++ b/tests/test_phase2_smoke.py
@@ -1,0 +1,27 @@
+import pandas as pd
+from datalake.aggregates.aggregate import _agg
+from datalake.levels import or_levels as ol
+
+def test_agg_barend():
+    ts = pd.date_range('2025-08-01 00:01:00+00:00', periods=3, freq='min')
+    df = pd.DataFrame({
+        'ts': ts,
+        'open': [1, 2, 3],
+        'high': [1, 2, 3],
+        'low': [1, 2, 3],
+        'close': [1, 2, 3],
+        'volume': [1, 1, 1],
+        'symbol': ['BTC-USD'] * 3,
+        'exchange': ['SIM'] * 3,
+    })
+    out = _agg(df, '5min')
+    assert {'open','high','low','close','volume'} <= set(out.columns)
+
+def test_levels_basic():
+    ts = pd.date_range('2025-08-01 00:01:00+00:00', periods=6, freq='min')
+    price = [10,11,12,13,12,11]
+    df = pd.DataFrame({'ts':ts,'open':price,'high':[p+0.1 for p in price],'low':[p-0.1 for p in price],'close':price,'volume':[1]*6})
+    def fake_loader(symbol, start, end, cfg): return df
+    ol.load_m1_range = fake_loader  # monkeypatch
+    out = ol.build_or_levels('BTC-USD','2025-08-01 00:00:00Z','2025-08-01 23:59:59Z', or_window='00:00-00:02', tz='UTC')
+    assert set(['or_high','or_low','break_dir']).issubset(out.columns)


### PR DESCRIPTION
## Summary
- add phase 2 usage guide for aggregates and OR levels
- link phase 2 guide from README
- add minimal smoke tests for aggregates and OR levels

## Testing
- `pytest tests/test_phase2_smoke.py`

------
https://chatgpt.com/codex/tasks/task_e_68c2e6627338832483bea6dc67924fae