### PR TITLE
docs+tests(phase3): guía de integración y smoke tests provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,14 @@ Más detalles en: [`docs/usage/ingest_crypto_m1.md`](docs/usage/ingest_crypto_m1
 ## Fase 2 · Agregados & Niveles (B&R)
 Ver guía: [`docs/usage/phase2_aggregates_levels.md`](docs/usage/phase2_aggregates_levels.md)
 
+
+
+## Fase 3 · Bridge Offline (backtest_crew)
+- Proveedor `LakeProvider` que entrega `df_exec` y `df_filter` con el mismo layout que IB.
+- Soporta TFs: M1/M5/M15/H1/D1 (usa agregados precomputados o *fallback* on-the-fly).
+
+```bash
+python -m bridge.backtest_crew.cli --symbol BTC-USD --from 2025-07-01 --to 2025-07-10 --exec-tf "1 min" --filter-tf "5 mins"
+```
+Más info: [`docs/usage/phase3_offline_bridge.md`](docs/usage/phase3_offline_bridge.md)
+

--- a/docs/usage/phase3_offline_bridge.md
+++ b/docs/usage/phase3_offline_bridge.md
@@ -1,0 +1,39 @@
+# Fase 3 — Bridge offline para backtest_crew
+
+Permite ejecutar el motor rápido B&R **sin IB**, leyendo del datalake.
+
+## Uso rápido
+```bash
+# 1) Instala este repo en el entorno donde corre backtest_crew
+pip install -e .
+
+# 2) (Opcional) fija la raíz del lake
+export LAKE_ROOT=/ruta/a/tu/datalake
+
+# 3) Smoke test
+python -m bridge.backtest_crew.cli \
+  --symbol BTC-USD --from 2025-07-01 --to 2025-07-10 \
+  --exec-tf "1 min" --filter-tf "5 mins"
+```
+
+## Integración en backtest_crew (sin tocar estrategia)
+En el sitio donde hoy pides datos a IB, invoca el provider:
+```python
+from bridge.backtest_crew.provider import LakeProvider
+from datalake.config import LakeConfig
+prov = LakeProvider(LakeConfig())
+df_exec, df_filter = prov.load_exec_and_filter(
+    symbol='BTC-USD',
+    start_utc='2025-07-01 00:00:00Z',
+    end_utc='2025-07-31 23:59:59Z',
+    exec_tf='1 min',
+    filter_tf='5 mins',
+)
+```
+- Columnas: `ts, open, high, low, close, volume` (más meta), ordenadas por `ts` (bar_end).
+- Si no existen agregados precomputados, el bridge resamplea **on-the-fly**.
+
+## Notas
+- Resampling con `label='right', closed='right'` (anti *lookahead*).
+- Recomendado tener agregados de **Fase 2** para velocidad.
+- `LAKE_ROOT` controla dónde están los Parquet.

--- a/src/bridge/backtest_crew/provider.py
+++ b/src/bridge/backtest_crew/provider.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Tuple
 import pandas as pd
@@ -10,11 +10,11 @@ from datalake.aggregates.aggregate import _agg as agg_fn  # para fallback on-the
 
 # ------------------------------- Utils -------------------------------
 _TF_RULE = {
-    '1 min': 'M1', '1min': 'M1', 'M1': 'M1',
-    '5 mins': 'M5', '5min': 'M5', 'M5': 'M5',
-    '15 mins': 'M15', '15min': 'M15', 'M15': 'M15',
-    '1 hour': 'H1', '60min': 'H1', 'H1': 'H1',
-    '1 day': 'D1', 'D1': 'D1'
+    '1min': 'M1', 'm1': 'M1',
+    '5mins': 'M5', '5min': 'M5', 'm5': 'M5',
+    '15mins': 'M15', '15min': 'M15', 'm15': 'M15',
+    '1hour': 'H1', '60min': 'H1', 'h1': 'H1',
+    '1day': 'D1', 'd1': 'D1'
 }
 _RULE_TO_PANDAS = {'M1':'1min','M5':'5min','M15':'15min','H1':'60min','D1':'1D'}
 
@@ -47,7 +47,7 @@ def _read_aggregate_parquet(cfg: LakeConfig, symbol: str, tf_norm: str, start: p
 # ----------------------------- Provider -----------------------------
 @dataclass
 class LakeProvider:
-    cfg: LakeConfig = LakeConfig()
+    cfg: LakeConfig = field(default_factory=LakeConfig)
 
     def load_exec_and_filter(self, symbol: str, start_utc: str, end_utc: str,
                              exec_tf: str = '1 min', filter_tf: str = '5 mins') -> Tuple[pd.DataFrame, pd.DataFrame]:

--- a/tests/test_phase3_provider_smoke.py
+++ b/tests/test_phase3_provider_smoke.py
@@ -1,0 +1,27 @@
+import pandas as pd
+from bridge.backtest_crew.provider import LakeProvider, _norm_tf, _agg_on_the_fly
+from datalake.config import LakeConfig
+
+
+def test_norm_tf():
+    assert _norm_tf('1 min') == 'M1'
+    assert _norm_tf('5 mins') == 'M5'
+    assert _norm_tf('1 day') == 'D1'
+
+
+def test_agg_on_the_fly_barend():
+    ts = pd.date_range('2025-08-01 00:01:00+00:00', periods=6, freq='min')
+    df = pd.DataFrame({
+        'ts': ts,
+        'open': [1, 2, 3, 4, 5, 6],
+        'high': [1, 2, 3, 4, 5, 6],
+        'low': [1, 2, 3, 4, 5, 6],
+        'close': [1, 2, 3, 4, 5, 6],
+        'volume': [1] * 6,
+        'symbol': ['BTC-USD'] * 6,
+        'exchange': ['SIM'] * 6,
+    })
+    out = _agg_on_the_fly(df, 'M5')
+    assert not out.empty and {'open','high','low','close'} <= set(out.columns)
+
+# Nota: test de integración completo requeriría ficheros Parquet reales en data/. Aquí hacemos humo sobre helpers.


### PR DESCRIPTION
## Summary
- documenta integración offline con `backtest_crew` y cómo ejecutar smoke test
- añade pruebas de humo para helpers del `LakeProvider`
- corrige normalización de timeframes y dataclass mutable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3252a13488324850b02f95ed6d882