### PR TITLE
Fase 2: tooling sintético (M1), resample M5/M15/H1, checkers y documentación + demo offline

### DIFF
--- a/tests/test_resample_offline.py
+++ b/tests/test_resample_offline.py
@@ -1,0 +1,22 @@
+import pandas as pd
+from datetime import datetime, timezone
+from tools.resample_from_m1 import resample_df
+
+
+def test_resample_counts():
+    # construye un día M1 completo
+    day = datetime(2025,8,1,tzinfo=timezone.utc)
+    idx = pd.date_range(day.replace(hour=0,minute=0,second=0,microsecond=0),
+                        day.replace(hour=23,minute=59,second=0,microsecond=0),
+                        freq="1min", tz="UTC")
+    df = pd.DataFrame({
+        "ts": idx,
+        "open": 1.0, "high": 2.0, "low": 0.5, "close": 1.5, "volume": 1
+    })
+    m5  = resample_df(df, "5min")
+    m15 = resample_df(df, "15min")
+    h1  = resample_df(df, "1H")
+    assert len(df) == 1440
+    assert len(m5) == 288
+    assert len(m15) == 96
+    assert len(h1) == 24

--- a/tools/check_mtf.py
+++ b/tools/check_mtf.py
@@ -1,0 +1,36 @@
+import argparse, glob, os, pandas as pd
+
+EXPECTED = {"M1":1440, "M5":288, "M15":96, "H1":24}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--lake-root", default=os.getenv("LAKE_ROOT", os.getcwd()))
+    ap.add_argument("--symbol", required=True)
+    ap.add_argument("--date", required=True)
+    ap.add_argument("--tf", required=True)
+    args = ap.parse_args()
+
+    base = os.path.join(args.lake_root, "data", "source=ibkr", "market=crypto", f"timeframe={args.tf}", f"symbol={args.symbol}")
+    yy, mm = args.date[:4], args.date[5:7]
+    patt = os.path.join(base, f"year={yy}", f"month={mm}", "*.parquet")
+    files = sorted(glob.glob(patt))
+    if not files:
+        print("No hay archivos para", args.tf, patt)
+        return 1
+
+    df = pd.concat((pd.read_parquet(f) for f in files), ignore_index=True)
+    df["ts"] = pd.to_datetime(df["ts"], utc=True)
+    start = pd.Timestamp(args.date + " 00:00:00+00:00")
+    end   = pd.Timestamp(args.date + " 23:59:00+00:00")
+    d = df[(df["ts"] >= start) & (df["ts"] <= end)].sort_values("ts").copy()
+
+    exp = EXPECTED.get(args.tf.upper())
+    print("tf:", args.tf, "| rows:", len(d), "| range:", d["ts"].min(), "->", d["ts"].max())
+    if exp:
+        print("expected_rows:", exp, "| ok:", len(d) == exp)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/offline_demo.ps1
+++ b/tools/offline_demo.ps1
@@ -1,0 +1,20 @@
+$ErrorActionPreference = 'Stop'
+$env:LAKE_ROOT = "$PSScriptRoot\.." | Resolve-Path
+$env:IB_EXCHANGE_CRYPTO = "PAXOS"
+$env:IB_WHAT_TO_SHOW    = "AGGTRADES"
+
+# 1) Generar M1 sintético (3 días)
+python .\tools\synth_gen.py --symbol BTC-USD --from 2025-08-01 --to 2025-08-03
+
+# 2) Checks M1 por día
+python .\tools\check_day.py --symbol BTC-USD --date 2025-08-01 --lake-root $env:LAKE_ROOT
+python .\tools\check_day.py --symbol BTC-USD --date 2025-08-02 --lake-root $env:LAKE_ROOT
+python .\tools\check_day.py --symbol BTC-USD --date 2025-08-03 --lake-root $env:LAKE_ROOT
+
+# 3) Resample M1 -> M5,M15,H1 para el rango
+python .\tools\resample_from_m1.py --symbol BTC-USD --from 2025-08-01 --to 2025-08-03 --to-tf M5,M15,H1
+
+# 4) Checks por TF (día 1)
+python .\tools\check_mtf.py --symbol BTC-USD --date 2025-08-01 --tf M5 --lake-root $env:LAKE_ROOT
+python .\tools\check_mtf.py --symbol BTC-USD --date 2025-08-01 --tf M15 --lake-root $env:LAKE_ROOT
+python .\tools\check_mtf.py --symbol BTC-USD --date 2025-08-01 --tf H1 --lake-root $env:LAKE_ROOT

--- a/tools/resample_from_m1.py
+++ b/tools/resample_from_m1.py
@@ -1,0 +1,79 @@
+import argparse, glob, os
+from types import SimpleNamespace
+import pandas as pd
+from datalake.ingestors.ibkr.writer import write_month
+
+AGG_MAP = {"open": "first", "high": "max", "low": "min", "close": "last", "volume": "sum"}
+
+TF_RULE = {"M5":"5min", "M15":"15min", "H1":"1H"}
+
+
+def resample_df(df_m1: pd.DataFrame, rule: str) -> pd.DataFrame:
+    d = df_m1.copy()
+    d["ts"] = pd.to_datetime(d["ts"], utc=True)
+    d = d.set_index("ts").sort_index()
+    ohlcv = d[["open","high","low","close","volume"]].resample(rule, label="left", closed="left").agg(AGG_MAP)
+    ohlcv = ohlcv.dropna(subset=["open","high","low","close"]).reset_index().rename(columns={"ts":"ts"})
+    return ohlcv
+
+
+def read_m1_range(lake_root: str, symbol: str, date_from: str, date_to: str) -> pd.DataFrame:
+    base = os.path.join(lake_root, "data", "source=ibkr", "market=crypto", "timeframe=M1", f"symbol={symbol}")
+    yy0, mm0 = date_from[:4], date_from[5:7]
+    yy1, mm1 = date_to[:4], date_to[5:7]
+    files = []
+    for yy in range(int(yy0), int(yy1)+1):
+        for mm in range(1,13):
+            if (yy == int(yy0) and mm < int(mm0)) or (yy == int(yy1) and mm > int(mm1)):
+                continue
+            patt = os.path.join(base, f"year={yy}", f"month={mm:02d}", "*.parquet")
+            files.extend(glob.glob(patt))
+    if not files:
+        raise SystemExit(f"No hay M1 para {symbol} en {base}")
+    df = pd.concat((pd.read_parquet(f) for f in sorted(set(files))), ignore_index=True)
+    df["ts"] = pd.to_datetime(df["ts"], utc=True)
+    mask = (df["ts"] >= pd.Timestamp(date_from + " 00:00:00+00:00")) & (df["ts"] <= pd.Timestamp(date_to + " 23:59:00+00:00"))
+    return df.loc[mask].copy()
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--lake-root", default=os.getenv("LAKE_ROOT", os.getcwd()))
+    ap.add_argument("--symbol", required=True)
+    ap.add_argument("--from", dest="date_from", required=True)
+    ap.add_argument("--to",   dest="date_to", required=True)
+    ap.add_argument("--to-tf", default="M5,M15,H1", help="Lista destino: M5,M15,H1")
+    args = ap.parse_args()
+
+    df = read_m1_range(args.lake_root, args.symbol, args.date_from, args.date_to)
+    if df.empty:
+        raise SystemExit("No hay datos M1 en el rango solicitado.")
+
+    targets = [t.strip().upper() for t in args.to_tf.split(",") if t.strip()]
+    wrote = []
+    for tf in targets:
+        rule = TF_RULE.get(tf)
+        if not rule:
+            print("TF no soportado:", tf); continue
+        out = resample_df(df, rule=rule)
+        # metadatos
+        out["source"]="ibkr"; out["market"]="crypto"; out["timeframe"]=tf; out["symbol"]=args.symbol
+        out["exchange"]=df.get("exchange").iloc[0] if "exchange" in df.columns and len(df) else "PAXOS"
+        out["what_to_show"]=df.get("what_to_show").iloc[0] if "what_to_show" in df.columns and len(df) else "AGGTRADES"
+        out["vendor"]="ibkr"; out["tz"]="UTC"
+
+        cfg = SimpleNamespace(
+            data_root=args.lake_root, market="crypto", timeframe=tf,
+            source="ibkr", vendor="ibkr",
+            exchange=out["exchange"].iloc[0], what_to_show=out["what_to_show"].iloc[0], tz="UTC",
+        )
+        p = write_month(out, symbol=args.symbol, cfg=cfg)
+        wrote.append((tf, len(out), p))
+
+    for tf, n, p in wrote:
+        print(f"OK {tf}: {n} filas → {p}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/synth_gen.py
+++ b/tools/synth_gen.py
@@ -1,0 +1,70 @@
+import argparse, os
+from types import SimpleNamespace
+from datetime import datetime, timedelta, timezone
+import numpy as np
+import pandas as pd
+from datalake.ingestors.ibkr.writer import write_month
+
+
+def make_m1(symbol: str, day_from: str, day_to: str, seed: int = 42) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    d0 = datetime.fromisoformat(day_from).replace(tzinfo=timezone.utc)
+    d1 = datetime.fromisoformat(day_to).replace(tzinfo=timezone.utc)
+
+    day = d0
+    frames = []
+    price0 = 100_000.0
+    while day <= d1:
+        idx = pd.date_range(day.replace(hour=0, minute=0, second=0, microsecond=0),
+                            day.replace(hour=23, minute=59, second=0, microsecond=0),
+                            freq="1min", tz="UTC")
+        steps = rng.normal(0, 10, len(idx))
+        px = price0 + steps.cumsum()
+        high = px + rng.uniform(0, 5, len(idx))
+        low  = px - rng.uniform(0, 5, len(idx))
+        open_ = px
+        close = px + rng.normal(0, 2, len(idx))
+        vol = rng.integers(0, 100, len(idx))
+
+        df = pd.DataFrame({
+            "ts": idx,
+            "open": open_, "high": high, "low": low, "close": close,
+            "volume": vol
+        })
+        frames.append(df)
+        price0 = float(close[-1])
+        day += timedelta(days=1)
+
+    out = pd.concat(frames, ignore_index=True)
+    out["source"]="ibkr"; out["market"]="crypto"; out["timeframe"]="M1"; out["symbol"]=symbol
+    out["exchange"]=os.getenv("IB_EXCHANGE_CRYPTO","PAXOS")
+    out["what_to_show"]=os.getenv("IB_WHAT_TO_SHOW","AGGTRADES")
+    out["vendor"]="ibkr"; out["tz"]="UTC"
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--symbol", required=True, help="BTC-USD, ETH-USD, etc.")
+    ap.add_argument("--from", dest="date_from", required=True, help="YYYY-MM-DD (UTC)")
+    ap.add_argument("--to",   dest="date_to",   required=True, help="YYYY-MM-DD (UTC)")
+    ap.add_argument("--seed", type=int, default=42)
+    args = ap.parse_args()
+
+    df = make_m1(args.symbol, args.date_from, args.date_to, seed=args.seed)
+
+    cfg = SimpleNamespace(
+        data_root=os.getenv("LAKE_ROOT", os.getcwd()),
+        market="crypto", timeframe="M1",
+        source="ibkr", vendor="ibkr",
+        exchange=os.getenv("IB_EXCHANGE_CRYPTO","PAXOS"),
+        what_to_show=os.getenv("IB_WHAT_TO_SHOW","AGGTRADES"),
+        tz="UTC",
+    )
+
+    path = write_month(df, symbol=args.symbol, cfg=cfg)
+    print("M1 sintético escrito en:", path, "| rows:", len(df))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add synth_gen script to generate synthetic M1 OHLCV data and persist monthly partitions
- Provide resample_from_m1 utility to create M5/M15/H1 aggregates and timeframe checker CLI
- Document offline workflow and chunked IB ingestion, with PowerShell demo

## Testing
- `python -m pytest -q`
- `PYTHONPATH=src python tools/synth_gen.py --symbol BTC-USD --from 2025-08-01 --to 2025-08-03`
- `python tools/check_day.py --symbol BTC-USD --date 2025-08-01 --lake-root $(pwd)`
- `PYTHONPATH=src python tools/resample_from_m1.py --symbol BTC-USD --from 2025-08-01 --to 2025-08-03 --to-tf M5,M15,H1`
- `python tools/check_mtf.py --symbol BTC-USD --date 2025-08-01 --tf M5 --lake-root $(pwd)`
- `python tools/check_mtf.py --symbol BTC-USD --date 2025-08-01 --tf M15 --lake-root $(pwd)`
- `python tools/check_mtf.py --symbol BTC-USD --date 2025-08-01 --tf H1 --lake-root $(pwd)`


------
https://chatgpt.com/codex/tasks/task_e_68c59a31598083249f32f5234ccedb69