### PR TITLE
chore: usar '1h' en resample para evitar FutureWarning

### DIFF
--- a/tools/resample_from_m1.py
+++ b/tools/resample_from_m1.py
@@ -5,7 +5,7 @@ from datalake.ingestors.ibkr.writer import write_month
 
 AGG_MAP = {"open": "first", "high": "max", "low": "min", "close": "last", "volume": "sum"}
 
-TF_RULE = {"M5":"5min", "M15":"15min", "H1":"1H"}
+TF_RULE = {"M5":"5min", "M15":"15min", "H1":"1h"}
 
 
 def resample_df(df_m1: pd.DataFrame, rule: str) -> pd.DataFrame:


### PR DESCRIPTION
## Summary
- evitar `FutureWarning` de pandas al usar alias de 1H

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c59cc0cbe0832494b88c074429f50b