### PR TITLE
feat: enhance ibkr ingest cli

### DIFF
--- a/src/datalake/ingestors/ibkr/ingest_cli.py
+++ b/src/datalake/ingestors/ibkr/ingest_cli.py
@@ -1,14 +1,37 @@
-import os
 import argparse
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+from typing import List
+
 import pandas as pd
-from datetime import datetime, timezone, timedelta
 from ib_insync import IB, Contract
+
 from datalake.config import LakeConfig
 from datalake.ingestors.ibkr.writer import write_month
 
 # --- Helpers de contrato, chunking y fetch robusto (2h) ---
 CHUNK_HOURS = 8
 BACKFILL_SLICE_HOURS = 2
+
+BAR_SIZES = {
+    "M1": "1 min",
+    "M5": "5 mins",
+    "M15": "15 mins",
+    "H1": "1 hour",
+    "D1": "1 day",
+}
+
+RESAMPLE_FREQ = {
+    "M1": "1min",
+    "M5": "5min",
+    "M15": "15min",
+    "H1": "1H",
+    "D1": "1D",
+}
+
+
+logger = logging.getLogger("ibkr.ingest")
 
 
 def _crypto_contract(symbol: str, exchange: str = "PAXOS") -> Contract:
@@ -28,24 +51,34 @@ def _day_chunks_utc(day_utc: datetime, chunk_hours: int = CHUNK_HOURS):
     return chunks
 
 
-def _fetch_m1_window(ib: IB, contract: Contract, start_utc: datetime, end_utc: datetime, what_to_show: str) -> pd.DataFrame:
-    dfs = []
+def _fetch_window(
+    ib: IB,
+    contract: Contract,
+    start_utc: datetime,
+    end_utc: datetime,
+    what_to_show: str,
+    timeframe: str,
+    use_rth: bool,
+) -> pd.DataFrame:
+    dfs: List[pd.DataFrame] = []
     cur_end = end_utc
-    # retrocede en slices de 2h para mayor tasa de acierto en HMDS
+    bar_size = BAR_SIZES.get(timeframe, "1 min")
     while cur_end >= start_utc:
         dur = f"{BACKFILL_SLICE_HOURS} H"
         bars = ib.reqHistoricalData(
             contract,
             endDateTime=cur_end,
             durationStr=dur,
-            barSizeSetting="1 min",
+            barSizeSetting=bar_size,
             whatToShow=what_to_show,
-            useRTH=False,
+            useRTH=use_rth,
             formatDate=2,
             keepUpToDate=False,
         )
         if bars:
-            df = pd.DataFrame(b.__dict__ for b in bars)[["date", "open", "high", "low", "close", "volume"]]
+            df = pd.DataFrame(b.__dict__ for b in bars)[
+                ["date", "open", "high", "low", "close", "volume"]
+            ]
             df["ts"] = pd.to_datetime(df["date"], utc=True)
             df = df.drop(columns=["date"]).sort_values("ts")
             df = df[(df["ts"] >= start_utc) & (df["ts"] <= end_utc)]
@@ -54,71 +87,155 @@ def _fetch_m1_window(ib: IB, contract: Contract, start_utc: datetime, end_utc: d
         cur_end = cur_end - timedelta(hours=BACKFILL_SLICE_HOURS)
     if not dfs:
         return pd.DataFrame(columns=["ts", "open", "high", "low", "close", "volume"])
-    out = pd.concat(dfs, ignore_index=True).drop_duplicates(subset=["ts"]).sort_values("ts")
+    out = (
+        pd.concat(dfs, ignore_index=True)
+        .drop_duplicates(subset=["ts"], keep="last")
+        .sort_values("ts")
+    )
     return out
 
 
-def main():
+def _resample(pdf: pd.DataFrame, timeframe: str) -> pd.DataFrame:
+    freq = RESAMPLE_FREQ.get(timeframe, "1min")
+    if timeframe == "M1":
+        return pdf
+    agg = {
+        "open": "first",
+        "high": "max",
+        "low": "min",
+        "close": "last",
+        "volume": "sum",
+    }
+    out = (
+        pdf.set_index("ts")
+        .resample(freq)
+        .agg(agg)
+        .dropna(subset=["open", "high", "low", "close"])
+        .reset_index()
+    )
+    return out
+
+
+def _build_parser() -> argparse.ArgumentParser:
     ap = argparse.ArgumentParser()
     ap.add_argument("--symbols", required=True, help="Lista separada por comas. Ej: BTC-USD,ETH-USD")
     ap.add_argument("--from", dest="date_from", required=True, help="YYYY-MM-DD (UTC)")
     ap.add_argument("--to", dest="date_to", required=True, help="YYYY-MM-DD (UTC)")
-    args = ap.parse_args()
+    ap.add_argument("--tf", choices=list(BAR_SIZES.keys()), default="M1")
+    ap.add_argument(
+        "--exchange",
+        default=os.getenv("IB_EXCHANGE_CRYPTO", "PAXOS"),
+        help="Exchange del contrato CRYPTO",
+    )
+    ap.add_argument(
+        "--what-to-show",
+        dest="what",
+        default=os.getenv("IB_WHAT_TO_SHOW", "AGGTRADES"),
+        help="Tipo de datos HMDS",
+    )
+    ap.add_argument("--rth", action="store_true", help="Usar Regular Trading Hours")
+    return ap
 
+
+def ingest(args, data_root: str | None = None) -> List[str]:
     symbols = [s.strip() for s in args.symbols.split(",") if s.strip()]
     d0 = datetime.fromisoformat(args.date_from).replace(tzinfo=timezone.utc)
     d1 = datetime.fromisoformat(args.date_to).replace(tzinfo=timezone.utc)
+    tf = args.tf
+    exchange = args.exchange
+    what = args.what
+    rth = bool(args.rth)
 
-    lake_root = os.getenv("LAKE_ROOT", os.getcwd())
-    exchange = os.getenv("IB_EXCHANGE_CRYPTO", "PAXOS")
-    what = os.getenv("IB_WHAT_TO_SHOW", "AGGTRADES")
+    lake_root = data_root or os.getenv("LAKE_ROOT", os.getcwd())
 
     cfg = LakeConfig()
     cfg.data_root = lake_root
     cfg.market = "crypto"
-    cfg.timeframe = "M1"
+    cfg.timeframe = tf
     cfg.source = "ibkr"
     cfg.vendor = "ibkr"
     cfg.exchange = exchange
     cfg.what_to_show = what
     cfg.tz = "UTC"
 
-    host = os.getenv("IB_HOST", "127.0.0.1")
-    port = int(os.getenv("IB_PORT", "7497"))
-    client_id = int(os.getenv("IB_CLIENT_ID", "1"))
+    synth = os.getenv("DATALAKE_SYNTH") == "1"
+    ib = None
+    if not synth:
+        host = os.getenv("IB_HOST", "127.0.0.1")
+        port = int(os.getenv("IB_PORT", "7497"))
+        client_id = int(os.getenv("IB_CLIENT_ID", "1"))
+        ib = IB()
+        ib.connect(host, port, clientId=client_id, timeout=15)
 
-    ib = IB()
-    ib.connect(host, port, clientId=client_id, timeout=15)
-
+    written: List[str] = []
     for sym in symbols:
-        print(f"Ingestando {sym} {args.date_from}→{args.date_to}")
+        logger.info("start %s %s→%s", sym, d0.date(), d1.date())
         cur = d0
         while cur <= d1:
-            all_dfs = []
-            for start_utc, end_utc in _day_chunks_utc(cur, CHUNK_HOURS):
-                cont = _crypto_contract(sym, exchange=exchange)
-                dfw = _fetch_m1_window(ib, cont, start_utc, end_utc, what_to_show=what)
-                if not dfw.empty:
-                    all_dfs.append(dfw)
-            if all_dfs:
-                day_df = pd.concat(all_dfs, ignore_index=True).drop_duplicates(subset=["ts"]).sort_values("ts")
-                # metadatos mínimos (writer también asegura schema)
-                day_df["source"] = "ibkr"
-                day_df["market"] = "crypto"
-                day_df["timeframe"] = "M1"
-                day_df["symbol"] = sym
-                day_df["exchange"] = exchange
-                day_df["what_to_show"] = what
-                day_df["vendor"] = "ibkr"
-                day_df["tz"] = "UTC"
-                # escribir (writer calcula y particiona por mes)
-                path = write_month(day_df, symbol=sym, cfg=cfg)
-                print(f"OK {sym} → {path}")
+            logger.info("day %s %s", sym, cur.date())
+            if synth:
+                day_df = pd.DataFrame(
+                    {
+                        "ts": [cur],
+                        "open": [1.0],
+                        "high": [1.0],
+                        "low": [1.0],
+                        "close": [1.0],
+                        "volume": [1.0],
+                    }
+                )
             else:
-                print(f"WARN {sym} {cur.date()}: sin barras devueltas por IB")
-            cur = (cur + timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
+                all_dfs: List[pd.DataFrame] = []
+                for start_utc, end_utc in _day_chunks_utc(cur, CHUNK_HOURS):
+                    cont = _crypto_contract(sym, exchange=exchange)
+                    dfw = _fetch_window(
+                        ib,
+                        cont,
+                        start_utc,
+                        end_utc,
+                        what_to_show=what,
+                        timeframe=tf,
+                        use_rth=rth,
+                    )
+                    if not dfw.empty:
+                        all_dfs.append(dfw)
+                if not all_dfs:
+                    logger.warning("no bars %s %s", sym, cur.date())
+                    cur = (cur + timedelta(days=1)).replace(
+                        hour=0, minute=0, second=0, microsecond=0
+                    )
+                    continue
+                day_df = (
+                    pd.concat(all_dfs, ignore_index=True)
+                    .drop_duplicates(subset=["ts"], keep="last")
+                    .sort_values("ts")
+                )
 
-    ib.disconnect()
+            day_df = _resample(day_df, tf)
+            day_df["source"] = "ibkr"
+            day_df["market"] = "crypto"
+            day_df["timeframe"] = tf
+            day_df["symbol"] = sym
+            day_df["exchange"] = exchange
+            day_df["what_to_show"] = what
+            day_df["vendor"] = "ibkr"
+            day_df["tz"] = "UTC"
+            path = write_month(day_df, symbol=sym, cfg=cfg)
+            written.append(path)
+            logger.info("end %s %s -> %s", sym, cur.date(), path)
+            cur = (cur + timedelta(days=1)).replace(
+                hour=0, minute=0, second=0, microsecond=0
+            )
+        logger.info("done %s", sym)
+
+    if ib is not None:
+        ib.disconnect()
+    return written
+
+
+def main(argv: List[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    ingest(args)
     return 0
 
 

--- a/tests/test_ingest_cli_args.py
+++ b/tests/test_ingest_cli_args.py
@@ -1,0 +1,32 @@
+import os
+import pandas as pd
+
+from datalake.ingestors.ibkr import ingest_cli
+
+
+def test_argparse_and_metadata(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATALAKE_SYNTH", "1")
+    # ensure defaults from env are used when flags omitted
+    monkeypatch.setenv("IB_EXCHANGE_CRYPTO", "PAXOS")
+    monkeypatch.setenv("IB_WHAT_TO_SHOW", "AGGTRADES")
+
+    parser = ingest_cli._build_parser()
+    args = parser.parse_args([
+        "--symbols",
+        "BTC-USD",
+        "--from",
+        "2024-01-01",
+        "--to",
+        "2024-01-01",
+    ])
+    assert args.tf == "M1"
+    assert args.exchange == "PAXOS"
+    assert args.what == "AGGTRADES"
+    assert args.rth is False
+
+    paths = ingest_cli.ingest(args, data_root=str(tmp_path))
+    assert paths and paths[0].endswith(".parquet")
+    df = pd.read_parquet(paths[0])
+    assert "timeframe" in df.columns and "symbol" in df.columns
+    assert (df["timeframe"] == "M1").all()
+    assert (df["symbol"] == "BTC-USD").all()


### PR DESCRIPTION
## Summary
- expand IBKR ingest CLI with timeframe, exchange, what-to-show and RTH options
- ensure written data carries full metadata and deduplication
- add synthetic ingest test covering arg parsing and parquet output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5d45efaf4832489efcec2fee78d5b