### PR TITLE
feat(aggregate): harden multi-TF resample and CLI

### DIFF
--- a/src/datalake/aggregates/cli.py
+++ b/src/datalake/aggregates/cli.py
@@ -4,6 +4,7 @@ from rich import print
 from datalake.config import LakeConfig
 from datalake.aggregates.loader import load_m1_range
 from datalake.aggregates.aggregate import aggregate_symbol
+from datetime import datetime, timezone
 
 
 def main(argv=None) -> int:
@@ -11,13 +12,27 @@ def main(argv=None) -> int:
     ap.add_argument('--symbols', required=True, help='BTC-USD,ETH-USD,...')
     ap.add_argument('--from', dest='date_from', required=True, help='YYYY-MM-DD (UTC)')
     ap.add_argument('--to', dest='date_to', required=True, help='YYYY-MM-DD (UTC)')
-    ap.add_argument('--tfs', default='M5,M15,H1,D1', help='Lista de TFs')
+    ap.add_argument('--to-tf', default='M5,M15,H1,D1', help='Lista de TFs destino (M5,M15,H1,D1)')
     args = ap.parse_args(argv)
 
-    cfg = LakeConfig(); tfs = [t.strip().upper() for t in args.tfs.split(',') if t.strip()]
+    cfg = LakeConfig(); tfs = [t.strip().upper() for t in args.to_tf.split(',') if t.strip()]
+    allowed = {'M5':288, 'M15':96, 'H1':24, 'D1':1}
+    tfs = [t for t in tfs if t in allowed]
+    date_from = datetime.strptime(args.date_from, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    date_to = datetime.strptime(args.date_to, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    days = (date_to - date_from).days + 1
+    expected_m1 = days * 1440
     for s in [x.strip() for x in args.symbols.split(',') if x.strip()]:
+        start = args.date_from+' 00:00:00Z'
+        end = args.date_to+' 23:59:59Z'
+        raw = load_m1_range(s, start, end, cfg)
+        if len(raw) != expected_m1:
+            print(f"[red]Falta M1[/red] {s} {args.date_from}→{args.date_to} (esperado {expected_m1}, obtenido {len(raw)})")
+            return 1
         print(f"[bold]Agregando[/bold] {s} {args.date_from}→{args.date_to} ({','.join(tfs)})")
-        results = aggregate_symbol(s, args.date_from+' 00:00:00Z', args.date_to+' 23:59:59Z', tfs, load_m1_range, cfg)
+        for tf in tfs:
+            print(f"[cyan]Esperadas[/cyan] {allowed[tf]*days} filas {tf}")
+        results = aggregate_symbol(s, start, end, tfs, lambda *_: raw, cfg)
         for tf, paths in results.items():
             for p in paths:
                 print(f"[green]OK[/green] {s} {tf} → {p}")

--- a/tests/test_resample_offline.py
+++ b/tests/test_resample_offline.py
@@ -3,20 +3,36 @@ from datetime import datetime, timezone
 from datalake.aggregates.aggregate import resample_df
 
 
-def test_resample_counts():
+def test_resample_counts_and_ranges():
     # construye un día M1 completo
-    day = datetime(2025,8,1,tzinfo=timezone.utc)
-    idx = pd.date_range(day.replace(hour=0,minute=0,second=0,microsecond=0),
-                        day.replace(hour=23,minute=59,second=0,microsecond=0),
+    day = datetime(2025, 8, 1, tzinfo=timezone.utc)
+    idx = pd.date_range(day.replace(hour=0, minute=0, second=0, microsecond=0),
+                        day.replace(hour=23, minute=59, second=0, microsecond=0),
                         freq="1min", tz="UTC")
     df = pd.DataFrame({
         "ts": idx,
         "open": 1.0, "high": 2.0, "low": 0.5, "close": 1.5, "volume": 1
     })
-    m5  = resample_df(df, "5min")
+    m5 = resample_df(df, "5min")
     m15 = resample_df(df, "15min")
-    h1  = resample_df(df, "1H")
+    h1 = resample_df(df, "1h")
+    d1 = resample_df(df, "1d")
     assert len(df) == 1440
     assert len(m5) == 288
     assert len(m15) == 96
     assert len(h1) == 24
+    assert len(d1) == 1
+    assert m5['ts'].iloc[0] == day.replace(hour=0, minute=0)
+    assert m5['ts'].iloc[-1] == day.replace(hour=23, minute=55)
+    assert m15['ts'].iloc[-1] == day.replace(hour=23, minute=45)
+    assert h1['ts'].iloc[-1] == day.replace(hour=23, minute=0)
+def test_resample_idempotent():
+    day = datetime(2025, 8, 1, tzinfo=timezone.utc)
+    idx = pd.date_range(day.replace(hour=0), day.replace(hour=23, minute=59), freq="1min", tz="UTC")
+    df = pd.DataFrame({
+        "ts": idx,
+        "open": 1.0, "high": 2.0, "low": 0.5, "close": 1.5, "volume": 1
+    })
+    once = resample_df(df, "5min")
+    twice = resample_df(once, "5min")
+    pd.testing.assert_frame_equal(once, twice)


### PR DESCRIPTION
## Summary
- add robust resample_df helper with UTC sorting, dedup and forward fill
- validate M1 existence and expected counts in aggregates CLI
- test resampler counts, ranges and idempotence

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5d5f0a10c83248aa3a2bbccecdde1