### PR TITLE
docs: expand usage guides for phases 1-4

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@ levels/
 - Niveles diarios **estrechos**: `session_date`, `pdh/pdl/pdc` (D-1), `or_start_utc/or_end_utc`, `orh/orl`.
 - **Crypto**: `what_to_show=AGGTRADES`, 24/7, sin RTH.
 
+## Quickstart (PowerShell)
+```powershell
+python -m venv .venv; .\\.venv\Scripts\Activate
+pip install -r requirements.txt
+$env:LAKE_ROOT="C:\\work\\backtest_crew-datalake"
+$env:IB_HOST="127.0.0.1"
+$env:IB_PORT="7497"
+$env:IB_CLIENT_ID="1"
+python -m datalake.ingestors.ibkr.ingest_cli --symbols BTC-USD --from 2025-08-01 --to 2025-08-01
+python .\\tools\\resample_from_m1.py --symbol BTC-USD --from 2025-08-01 --to 2025-08-01 --to-tf M5
+python .\\tools\\check_day.py --symbol BTC-USD --date 2025-08-01 --lake-root $env:LAKE_ROOT
+python .\\tools\\check_mtf.py --symbol BTC-USD --date 2025-08-01 --tf M5 --lake-root $env:LAKE_ROOT
+```
+
 ## Próximas fases
 - Fase 1: Ingesta offline M1 (BTC-USD, ETH-USD) y validación.
 - Fase 2: Agregados (M5/M15/H1/D1) y niveles diarios.
@@ -175,6 +189,12 @@ python -m datalake.read.cli join-mtf --lake-root $env:LAKE_ROOT --symbol BTC-USD
 | 3    | Idempotencia/merge seguro en escritor (Parquet mensual) + normalización de esquema | ✅ Completado |
 | 4    | Reader API + Alineación Multi-TF (asof) + CLIs y docs | ✅ Completado |
 
+## Ramas activas
+| Rama   | Alcance |
+|--------|---------|
+| phase-3 | Ingesta M1, agregados y validadores básicos |
+| phase-4 | CLI endurecida, agregador robusto y documentación extendida |
+
 ### Quickstart (PowerShell)
 ```powershell
 # 1) Instalar en editable
@@ -207,6 +227,7 @@ python -m datalake.read.cli join-mtf --lake-root $env:LAKE_ROOT --symbol BTC-USD
 - `docs/usage/phase2.md`
 - `docs/usage/phase3.md`
 - `docs/usage/phase4.md`
+- `docs/usage/phase-4.md`
 - `docs/usage/reader.md`
 - `docs/usage/mtf.md`
 - `docs/usage/tools.md`

--- a/docs/usage/phase-4.md
+++ b/docs/usage/phase-4.md
@@ -1,0 +1,25 @@
+# Fase 4 — CLI endurecida y recetas end-to-end
+
+## Cambios clave
+- CLI con argumentos completos, validaciones y logs más verbosos.
+- Agregador reforzado contra gaps y duplicados.
+
+## Receta end-to-end
+```powershell
+# Ingesta real
+python -m datalake.ingestors.ibkr.ingest_cli --symbols BTC-USD --from 2025-08-01 --to 2025-08-01
+# o modo sintético
+$env:DATALAKE_SYNTH = "1"
+python -m datalake.ingestors.ibkr.ingest_cli --symbols BTC-USD --from 2025-08-01 --to 2025-08-01
+# Agregados M5/M15/H1
+python .\\tools\\resample_from_m1.py --symbol BTC-USD --from 2025-08-01 --to 2025-08-01 --to-tf M5,M15,H1
+# Validaciones
+python .\\tools\\check_day.py  --symbol BTC-USD --date 2025-08-01 --lake-root $env:LAKE_ROOT
+python .\\tools\\check_mtf.py  --symbol BTC-USD --date 2025-08-01 --tf M5 --lake-root $env:LAKE_ROOT
+```
+
+## Buenas prácticas
+- Reintentos por día completo, nunca parciales.
+- Verificar huecos con `check_day.py` antes de resample.
+- Las operaciones son idempotentes: reingestión y resample no generan duplicados.
+

--- a/docs/usage/phase1.md
+++ b/docs/usage/phase1.md
@@ -1,13 +1,19 @@
 # Fase 1 — Ingesta IBKR (Crypto)
 
+### Preparación
+```powershell
+python -m venv .venv; .\.venv\Scripts\Activate
+pip install -r requirements.txt
+$env:LAKE_ROOT = "C:\\work\\backtest_crew-datalake"
+```
+
 ### Variables
 - `IB_HOST`, `IB_PORT`, `IB_CLIENT_ID`
 - `IB_EXCHANGE_CRYPTO` = `PAXOS`
 - `IB_WHAT_TO_SHOW` = `AGGTRADES` (Crypto **requiere** `AGGTRADES`).
 
-### Ejecución (PowerShell)
+### Ejecución real (PowerShell)
 ```powershell
-$env:LAKE_ROOT = "C:\\work\\backtest_crew-datalake"
 $env:IB_HOST = "127.0.0.1"; $env:IB_PORT = "7497"; $env:IB_CLIENT_ID = "1"
 $env:IB_EXCHANGE_CRYPTO = "PAXOS"; $env:IB_WHAT_TO_SHOW = "AGGTRADES"
 
@@ -15,7 +21,11 @@ python -m datalake.ingestors.ibkr.ingest_cli --symbols BTC-USD \
   --from 2025-08-01 --to 2025-08-01
 ```
 
-### Salida
+### Layout del lago
+`data/source=<src>/market=<mkt>/timeframe=<tf>/symbol=<sym>/year=YYYY/month=MM/part-YYYY-MM.parquet`
+
+### Notas
 - Escribe/actualiza `part-YYYY-MM.parquet` de **M1**.
 - Re-ejecuciones son **seguras**: mergean por `ts` sin duplicados.
+- Si la ingesta falla, reintentar por día completo; la merge es idempotente.
 

--- a/docs/usage/phase2.md
+++ b/docs/usage/phase2.md
@@ -10,14 +10,20 @@ python .\\tools\\synth_gen.py --symbol BTC-USD --from 2025-08-01 --to 2025-08-03
 # Nota: usar '1h' en vez de '1H' para evitar FutureWarning
 python .\\tools\\resample_from_m1.py --symbol BTC-USD --from 2025-08-01 --to 2025-08-03 --to-tf M5,M15,H1
 ```
+Cada día debe producir exactamente:
+- M5 → **288** velas
+- M15 → **96** velas
+- H1 → **24** velas
 
-### Validadores
+### Validadores de integridad
 ```powershell
-python .\\tools\\check_day.py --symbol BTC-USD --date 2025-08-01 --lake-root $env:LAKE_ROOT
+python .\\tools\\check_day.py  --symbol BTC-USD --date 2025-08-01 --lake-root $env:LAKE_ROOT  # espera 1440 filas
 python .\\tools\\check_mtf.py --symbol BTC-USD --date 2025-08-01 --tf M5 --lake-root $env:LAKE_ROOT
+python .\\tools\\check_mtf.py --symbol BTC-USD --date 2025-08-01 --tf M15 --lake-root $env:LAKE_ROOT
+python .\\tools\\check_mtf.py --symbol BTC-USD --date 2025-08-01 --tf H1 --lake-root $env:LAKE_ROOT
 ```
 
-#### Conteos esperados por día
+### Conteos esperados por día
 - M1: **1440**
 - M5: **288**
 - M15: **96**

--- a/docs/usage/phase3.md
+++ b/docs/usage/phase3.md
@@ -1,10 +1,18 @@
 # Fase 3 — Escritura idempotente y normalización
 
 - **Normalización de esquema** al escribir/leer: tipos consistentes y columnas canónicas.
-- **Idempotencia**: si el archivo mensual existe, se **lee**, se mergea el nuevo bloque (por `ts`) y se re-escribe.
+- **Idempotencia**: si el archivo mensual existe, `write_month` lo **lee**, mergea el nuevo bloque por `ts` y lo re-escribe sin duplicados.
 - **Corrección de límites**: ingesta por **trozos intra-día** (para IB) + merge mensual ⇒ evita huecos y solapes.
+
+### Modo sintético (sin IB)
+```powershell
+$env:DATALAKE_SYNTH = "1"
+python -m datalake.ingestors.ibkr.ingest_cli --symbols BTC-USD --from 2025-08-01 --to 2025-08-01
+```
+Cuando IB está caído, el ingestor genera velas sintéticas para no interrumpir el pipeline.
 
 ### Re-ingesta del mismo día
 - Seguro: actualiza o completa huecos.
 - En caso de conflicto `ts`, **último gana**.
+- Reintentar siempre por día completo para conservar la idempotencia.
 


### PR DESCRIPTION
## Summary
- extend phase 1–3 usage docs with setup, validation and retry guidance
- add phase-4 guide with end-to-end recipes and ops best practices
- update README with 10-line quickstart and branch scope table

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5d74c0b388324adea8bf0f0072250