### PR TITLE
fix: unify project.scripts block in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,14 +18,12 @@ dependencies = [
 [tool.setuptools.packages.find]
 where = ["src"]
 
+# Consolidated console scripts to avoid duplicate declarations
 [project.scripts]
 # CLIs útiles ya presentes en el repo
-datalake-ingest = "datalake.ingest.cli:main"
-datalake-aggregates = "datalake.aggregates.cli:main"
-datalake-levels = "datalake.levels.cli:main"
 bridge-bc-smoke = "bridge.backtest_crew.cli:main"
-datalake-read = "datalake.read.cli:main"
+datalake-aggregates = "datalake.aggregates.cli:main"
+datalake-ingest = "datalake.ingest.cli:main"
 datalake-join-mtf = "datalake.read.cli:main"
-
-[project.scripts]
+datalake-levels = "datalake.levels.cli:main"
 datalake-read = "datalake.read.cli:main"


### PR DESCRIPTION
## Summary
- consolidate console scripts under a single [project.scripts] table to avoid TOML duplicate key error

## Testing
- `python -m pip install -e . --no-deps`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5f4f093848324adb02a647cd43646