### PR TITLE
IBKR: replace hour-based durationStr with seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ python .\\tools\\check_mtf.py --symbol BTC-USD --date 2025-08-01 --tf M5 --lake-
 python -m datalake.read.cli read --lake-root $env:LAKE_ROOT --market crypto --tf M1 --symbol BTC-USD --from 2025-08-01 --to 2025-08-03 --head 5
 python -m datalake.read.cli join-mtf --lake-root $env:LAKE_ROOT --symbol BTC-USD --exec-tf M1 --from 2025-08-01 --to 2025-08-01 --ctx-tf M5,M15,H1 --out-csv mtf_join.csv
 ```
+> **IB Error 321**: el ingestor ahora expresa la duración en segundos o usa `"1 D"` para ventanas diarias de M1, evitando la unidad `H` que IB rechaza.
 
 ### Documentación
 - `docs/overview.md`

--- a/docs/usage/phase-4.md
+++ b/docs/usage/phase-4.md
@@ -23,3 +23,8 @@ python .\\tools\\check_mtf.py  --symbol BTC-USD --date 2025-08-01 --tf M5 --lake
 - Verificar huecos con `check_day.py` antes de resample.
 - Las operaciones son idempotentes: reingestión y resample no generan duplicados.
 
+### IB Error 321
+Si IB devuelve `Error 321` por `duration format`, revisa la versión del ingestor.
+Las solicitudes ahora expresan la duración en segundos (`"{N} S"`) o usan
+`"1 D"` para ventanas diarias de M1, evitando la unidad `H`.
+


### PR DESCRIPTION
## Summary
- compute reqHistoricalData duration in seconds and use '1 D' for full-day M1 windows
- log durationStr, barSize, endDateTime; ensure useRTH is numeric and end timestamps formatted
- document IB "Error 321" workaround in phase-4 usage and README

## Testing
- `python -m pip install -e .`
- `pytest -q`
- `DATALAKE_SYNTH=1 python -m datalake.ingestors.ibkr.ingest_cli --symbols BTC-USD --from 2025-08-01 --to 2025-08-01 --tf M1 --exchange PAXOS --what-to-show AGGTRADES` (no output)
- `python tools/synth_gen.py --symbol BTC-USD --from 2025-08-01 --to 2025-08-01`
- `python tools/check_day.py --symbol BTC-USD --date 2025-08-01 --lake-root .`

------
https://chatgpt.com/codex/tasks/task_e_68c5f794cdb48324923ed25edc9e0585