### PR TITLE
IBKR CRYPTO M1: fallback multi-grano con logs detallados y relleno sintético opcional

### DIFF
--- a/src/datalake/ingestors/ibkr/writer.py
+++ b/src/datalake/ingestors/ibkr/writer.py
@@ -25,7 +25,8 @@ SCHEMA = pa.schema([
     pa.field("exchange", pa.string()),
     pa.field("what_to_show", pa.string()),
     pa.field("vendor", pa.string()),
-    pa.field("tz", pa.string())
+    pa.field("tz", pa.string()),
+    pa.field("is_synth", pa.bool_()),
 ])
 
 # -- Asegurar metadatos requeridos antes del schema --
@@ -77,6 +78,8 @@ def _ensure_metadata(pdf: pd.DataFrame, symbol: str, cfg) -> pd.DataFrame:
                 pdf[k] = pdf[k].fillna(v)
             except Exception:
                 pdf[k] = v
+    if "is_synth" not in pdf.columns:
+        pdf["is_synth"] = False
     return pdf
 
 
@@ -94,6 +97,8 @@ def _normalize_schema_pdf(pdf: pd.DataFrame) -> pd.DataFrame:
     for c in TEXT_COLS:
         if c in pdf:
             pdf[c] = pdf[c].astype("string")
+    if "is_synth" in pdf:
+        pdf["is_synth"] = pdf["is_synth"].astype("bool")
     return pdf
 
 

--- a/tools/check_day.py
+++ b/tools/check_day.py
@@ -41,6 +41,9 @@ def main():
     d = df[(df["ts"] >= start) & (df["ts"] <= end)].sort_values("ts").copy()
 
     print("rows:", len(d), "| range:", d["ts"].min(), "->", d["ts"].max())
+    if "is_synth" in d.columns:
+        synth_cnt = int(d["is_synth"].sum())
+        print("synthetic_bars:", synth_cnt)
     per_hour = (
         d.set_index("ts").groupby(d["ts"].dt.hour).size().reindex(range(24), fill_value=0)
     )
@@ -65,6 +68,9 @@ def main():
         print("missing_ranges:")
         for a, b in ranges:
             print(f"  {a.isoformat()} -> {b.isoformat()}")
+            print(
+                f"    first_missing: {a.isoformat()} last_missing: {b.isoformat()}"
+            )
     return 0
 
 


### PR DESCRIPTION
## Summary
- Add `fetch_hist_bars` with detailed debug logging for HMDS requests.
- Repair missing minute ranges with multi-grain (1h→30m→10m→5m) fallback and optional synthetic gap fill.
- Expose `--allow-synth` and `--log-level` flags; track synthetic bars in parquet and check_day tool.

## Testing
- `pytest`
- `python -m datalake.ingestors.ibkr.repair_day_cli --symbol BTC-USD --date 2025-08-01 --tf M1 --exchange PAXOS --what-to-show AGGTRADES --log-level DEBUG` *(fails: Connect call failed ('127.0.0.1', 7497))*
- `DATALAKE_SYNTH=1 python -m datalake.ingestors.ibkr.repair_day_cli --symbol BTC-USD --date 2025-08-01 --tf M1 --exchange PAXOS --what-to-show AGGTRADES --allow-synth --log-level DEBUG`
- `python tools/check_day.py --symbol BTC-USD --date 2025-08-01`
- `python tools/check_day.py --symbol BTC-USD --date 2025-08-02`

------
https://chatgpt.com/codex/tasks/task_e_68c6e3ebbda08324820fdf6be4dfed55