### PR TITLE
Arreglar ingesta de cripto 24/7 (faltan 4h 20:00–23:59 UTC) en phase-4

### DIFF
--- a/tests/test_ingest_cli_args.py
+++ b/tests/test_ingest_cli_args.py
@@ -8,7 +8,7 @@ def test_argparse_and_metadata(tmp_path, monkeypatch):
     monkeypatch.setenv("DATALAKE_SYNTH", "1")
     # ensure defaults from env are used when flags omitted
     monkeypatch.setenv("IB_EXCHANGE_CRYPTO", "PAXOS")
-    monkeypatch.setenv("IB_WHAT_TO_SHOW", "AGGTRADES")
+    monkeypatch.delenv("IB_WHAT_TO_SHOW", raising=False)
 
     parser = ingest_cli._build_parser()
     args = parser.parse_args([
@@ -21,8 +21,8 @@ def test_argparse_and_metadata(tmp_path, monkeypatch):
     ])
     assert args.tf == "M1"
     assert args.exchange == "PAXOS"
-    assert args.what == "AGGTRADES"
-    assert args.rth is False
+    assert args.what is None
+    assert args.use_rth is None
 
     paths = ingest_cli.ingest(args, data_root=str(tmp_path))
     assert paths and paths[0].endswith(".parquet")
@@ -30,3 +30,4 @@ def test_argparse_and_metadata(tmp_path, monkeypatch):
     assert "timeframe" in df.columns and "symbol" in df.columns
     assert (df["timeframe"] == "M1").all()
     assert (df["symbol"] == "BTC-USD").all()
+    assert (df["what_to_show"] == "TRADES").all()


### PR DESCRIPTION
## Summary
- force `useRTH=0` and `whatToShow=TRADES` for PAXOS crypto symbols, add CLI overrides and chunk-level retries
- add strict mode to daily check tool with detailed gap reporting

## Testing
- `pytest -vv`
- `PYTHONPATH=src python tools/check_day.py --symbol BTC-USD --date 2025-08-01 --lake-root . --strict`


------
https://chatgpt.com/codex/tasks/task_e_68c6fd9a0dec8324acf9021eed3da717