### PR TITLE
Phase-4 | IBKR Crypto en PAXOS: permitir AGGTRADES, fallback 10299 y 24/7 (useRTH=0)

### DIFF
--- a/src/datalake/commands/repair_day.py
+++ b/src/datalake/commands/repair_day.py
@@ -3,7 +3,15 @@ from __future__ import annotations
 import pandas as pd
 
 
-def repair_day(symbol: str, date_utc: str, timeframe: str, exchange: str, what_to_show: str, cfg) -> None:
+def repair_day(
+    symbol: str,
+    date_utc: str,
+    timeframe: str,
+    exchange: str,
+    what_to_show: str,
+    use_rth: bool,
+    cfg,
+) -> None:
     from datalake.ingestors.ibkr.downloader import fetch_bars_range, bars_to_df
     from datalake.ingestors.ibkr.writer import write_month
     from datalake.tools.gaps import find_missing_ranges_utc
@@ -38,6 +46,7 @@ def repair_day(symbol: str, date_utc: str, timeframe: str, exchange: str, what_t
             duration_seconds=int((fetch_end - g_start).total_seconds()),
             timeframe=timeframe,
             what_to_show=what_to_show,
+            use_rth=use_rth,
         )
         df_part = bars_to_df(bars, exchange=exchange)
         df_part = df_part[(df_part['ts'] >= g_start) & (df_part['ts'] <= g_end)]

--- a/src/datalake/ingestors/ibkr/repair_day_cli.py
+++ b/src/datalake/ingestors/ibkr/repair_day_cli.py
@@ -19,6 +19,13 @@ def _build_parser() -> argparse.ArgumentParser:
         dest="what",
         default=os.getenv("IB_WHAT_TO_SHOW", "AGGTRADES"),
     )
+    ap.add_argument(
+        "--use-rth",
+        dest="use_rth",
+        choices=[0, 1],
+        type=int,
+        default=int(os.getenv("IB_USE_RTH", "0")),
+    )
     ap.add_argument("--lake-root", default=os.getenv("LAKE_ROOT", os.getcwd()))
     ap.add_argument("--allow-synth", action="store_true", help="Relleno sintético")
     ap.add_argument(
@@ -34,6 +41,7 @@ def repair_day(args) -> str:
     tf = args.tf
     exchange = args.exchange
     what = args.what
+    rth = bool(args.use_rth)
     lake_root = args.lake_root
 
     cfg = LakeConfig()
@@ -44,6 +52,7 @@ def repair_day(args) -> str:
     cfg.vendor = "ibkr"
     cfg.exchange = exchange
     cfg.what_to_show = what
+    cfg.use_rth = rth
     cfg.tz = "UTC"
     cfg.logger = logger
 
@@ -53,6 +62,7 @@ def repair_day(args) -> str:
         timeframe=tf,
         exchange=exchange,
         what_to_show=what,
+        use_rth=rth,
         cfg=cfg,
     )
     return getattr(cfg, "last_dest_file", "")

--- a/tests/test_ingest_cli_args.py
+++ b/tests/test_ingest_cli_args.py
@@ -30,4 +30,4 @@ def test_argparse_and_metadata(tmp_path, monkeypatch):
     assert "timeframe" in df.columns and "symbol" in df.columns
     assert (df["timeframe"] == "M1").all()
     assert (df["symbol"] == "BTC-USD").all()
-    assert (df["what_to_show"] == "TRADES").all()
+    assert (df["what_to_show"] == "AGGTRADES").all()


### PR DESCRIPTION
## Summary
- allow AGGTRADES in ingest CLI and auto-select it for crypto symbols
- retry HMDS requests with AGGTRADES on IB error 10299
- default crypto ingestion to useRTH=0 while keeping user overrides and logging detailed request params

## Testing
- `pip install -e .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c703d12050832487d22271e644f0d2