### PR TITLE
Phase-4: add Binance data source with UTC klines

### DIFF
--- a/docs/README_BINANCE.md
+++ b/docs/README_BINANCE.md
@@ -1,0 +1,30 @@
+# Source: Binance (Phase-4)
+
+Ingesta alternativa a IB para klines spot 1m/5m (UTC), sin credenciales.
+
+## Símbolos
+- Lógico del proyecto: `BTC-USD` (etc.)
+- Binance Spot: `BTCUSDT` (mapping automático)
+
+## CLI
+```bash
+python -m datalake.ingestors.binance.ingest_cli \
+  --symbols BTC-USD,ETH-USD \
+  --from 2025-08-01 --to 2025-08-03 \
+  --tf M1 \
+  --binance-region global
+```
+
+## Tail focalizado (20:00–23:59 UTC)
+```bash
+python tools/binance_fetch_tail.py \
+  --date 2025-08-01 \
+  --symbol BTC-USD \
+  --region global \
+  --out ./tmp/BTC-USD_2025-08-01_tail_binance.csv
+```
+
+## Notas
+- Timestamps tz-aware en UTC.
+- Dedupe/merge idéntico al de IB (clave: symbol, tf, ts, source).
+- Para Binance.US usar `--binance-region us`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ dependencies = [
   "pyarrow>=14",
   "rich>=13.7",
   "pytz>=2024.1",
-  "python-dotenv>=1.0.1"
+  "python-dotenv>=1.0.1",
+  "requests>=2.28.0"
 ]
 
 [tool.setuptools.packages.find]

--- a/src/datalake/ingestors/binance/__init__.py
+++ b/src/datalake/ingestors/binance/__init__.py
@@ -1,0 +1,1 @@
+"""Binance ingestors."""

--- a/src/datalake/ingestors/binance/ingest_cli.py
+++ b/src/datalake/ingestors/binance/ingest_cli.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+import os
+import argparse
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from datalake.providers.binance.client import fetch_klines
+from datalake.utils.symbols.binance_map import to_binance_symbol
+
+UTC = timezone.utc
+
+TF_CHOICES = ['M1','M5']
+
+def _dt_utc(d: str, h: int, m: int, s: int = 0) -> datetime:
+    y, mo, da = map(int, d.split('-'))
+    return datetime(y, mo, da, h, m, s, tzinfo=UTC)
+
+def _days_iter(date_from: str, date_to: str):
+    d0 = datetime.strptime(date_from, '%Y-%m-%d').date()
+    d1 = datetime.strptime(date_to, '%Y-%m-%d').date()
+    cur = d0
+    while cur <= d1:
+        yield cur.isoformat()
+        cur = cur + timedelta(days=1)
+
+def _expect_rows(tf: str) -> int:
+    return 1440 if tf == 'M1' else (288 if tf == 'M5' else None)
+
+def _add_control_cols(df: pd.DataFrame, symbol_logico: str, tf: str, region: str) -> pd.DataFrame:
+    if df is None or df.empty:
+        return df
+    df = df.copy()
+    df['symbol'] = symbol_logico
+    df['tf'] = tf
+    df['source'] = 'binance'
+    df['exchange'] = 'BINANCE.US' if region == 'us' else 'BINANCE'
+    return df
+
+def write_merge_dedupe(df: pd.DataFrame, *, root: str | None = None) -> str:
+    if df is None or df.empty:
+        return ""
+    root = root or os.getenv("LAKE_ROOT", os.getcwd())
+    symbol = df['symbol'].iloc[0]
+    tf = df['tf'].iloc[0]
+    year = int(df['ts'].dt.year.iloc[0])
+    month = int(df['ts'].dt.month.iloc[0])
+    base = (
+        Path(root)
+        / "data"
+        / "source=binance"
+        / "market=crypto"
+        / f"timeframe={tf}"
+        / f"symbol={symbol}"
+        / f"year={year}"
+        / f"month={month:02d}"
+    )
+    base.mkdir(parents=True, exist_ok=True)
+    dest_file = base / f"part-{year}-{month:02d}.parquet"
+    existing = pd.DataFrame()
+    if dest_file.exists():
+        try:
+            existing = pq.read_table(dest_file).to_pandas()
+        except Exception:
+            existing = pd.read_parquet(dest_file)
+    merged = pd.concat([existing, df], ignore_index=True)
+    merged['ts'] = pd.to_datetime(merged['ts'], utc=True)
+    merged = merged.drop_duplicates(
+        subset=['symbol', 'tf', 'ts', 'source'], keep='last'
+    ).sort_values('ts')
+    table = pa.Table.from_pandas(merged, preserve_index=False)
+    pq.write_table(table, dest_file, compression="zstd", version="2.6", use_dictionary=False)
+    return str(dest_file)
+
+def ingest(args: argparse.Namespace) -> None:
+    symbols = [s.strip() for s in args.symbols.split(',') if s.strip()]
+    for sym in symbols:
+        b_sym = to_binance_symbol(sym)
+        for day in _days_iter(args.date_from, args.date_to):
+            start = _dt_utc(day, 0, 0, 0)
+            end   = _dt_utc(day, 23, 59, 0)
+            df = fetch_klines(
+                symbol=b_sym,
+                start_dt=start,
+                end_dt=end,
+                tf=args.tf,
+                region=args.binance_region
+            )
+            df = _add_control_cols(df, sym, args.tf, args.binance_region)
+            if df is not None and not df.empty:
+                write_merge_dedupe(df)
+            exp = _expect_rows(args.tf)
+            if exp is not None:
+                rows = 0 if df is None else len(df)
+                if rows != exp:
+                    print(f"[WARN] {sym} {day} tf={args.tf}: filas={rows} (esperado={exp})")
+
+def main() -> int:
+    p = argparse.ArgumentParser(description='Ingesta Binance (source=binance) — Phase-4')
+    p.add_argument('--symbols', required=True, help='Lista separada por comas, e.g. BTC-USD,ETH-USD')
+    p.add_argument('--from', dest='date_from', required=True, help='YYYY-MM-DD (UTC)')
+    p.add_argument('--to', dest='date_to', required=True, help='YYYY-MM-DD (UTC)')
+    p.add_argument('--tf', choices=TF_CHOICES, default='M1')
+    p.add_argument('--binance-region', choices=['global','us'], default=os.getenv('BINANCE_REGION','global'))
+    args = p.parse_args()
+    ingest(args)
+    return 0
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/src/datalake/providers/binance/__init__.py
+++ b/src/datalake/providers/binance/__init__.py
@@ -1,0 +1,1 @@
+"""Binance data providers."""

--- a/src/datalake/providers/binance/client.py
+++ b/src/datalake/providers/binance/client.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+import time
+import math
+from typing import Literal, Optional
+from datetime import datetime, timezone
+import requests
+import pandas as pd
+
+UTC = timezone.utc
+
+BASE_URLS = {
+    'global': 'https://api.binance.com',
+    'us': 'https://api.binance.us',
+}
+
+_INTERVALS = {
+    'M1': '1m',
+    'M5': '5m',
+}
+
+class BinanceHTTPError(Exception):
+    pass
+
+def _to_ms(dt: datetime) -> int:
+    return int(dt.timestamp() * 1000)
+
+def _rate_limited_get(url: str, params: dict, max_retries: int = 5, timeout: int = 30) -> requests.Response:
+    for i in range(max_retries):
+        r = requests.get(url, params=params, timeout=timeout)
+        if r.status_code == 429:
+            sleep_s = min(2 ** i, 10)
+            time.sleep(sleep_s)
+            continue
+        if 200 <= r.status_code < 300:
+            return r
+        # 5xx retry suave
+        if 500 <= r.status_code < 600:
+            time.sleep(1.5)
+            continue
+        # Errores duros
+        raise BinanceHTTPError(f"HTTP {r.status_code}: {r.text}")
+    raise BinanceHTTPError(f"Rate limit persistente: {r.status_code} {r.text}")
+
+def fetch_klines(
+    symbol: str,
+    start_dt: datetime,
+    end_dt: datetime,
+    tf: Literal['M1','M5'] = 'M1',
+    region: Literal['global','us'] = 'global'
+) -> pd.DataFrame:
+    if tf not in _INTERVALS:
+        raise ValueError(f"Intervalo no soportado para Binance: {tf}")
+    if start_dt.tzinfo is None or end_dt.tzinfo is None:
+        raise ValueError("start_dt y end_dt deben ser tz-aware UTC")
+    base_url = BASE_URLS[region]
+    url = f"{base_url}/api/v3/klines"
+    params = {
+        'symbol': symbol,
+        'interval': _INTERVALS[tf],
+        'startTime': _to_ms(start_dt),
+        'endTime': _to_ms(end_dt),
+        'limit': 1000
+    }
+    r = _rate_limited_get(url, params)
+    data = r.json()
+    if not isinstance(data, list):
+        raise BinanceHTTPError(f"Respuesta inesperada: {data}")
+    cols = [
+        'openTime','open','high','low','close','volume','closeTime',
+        'qav','numTrades','takerBuyBase','takerBuyQuote','ignore'
+    ]
+    df = pd.DataFrame(data, columns=cols)
+    if df.empty:
+        return df
+    df['ts'] = pd.to_datetime(df['openTime'], unit='ms', utc=True)
+    for c in ('open','high','low','close','volume'):
+        df[c] = pd.to_numeric(df[c], errors='coerce')
+    # Devolver sólo columnas del timeseries
+    df = df[['ts','open','high','low','close','volume']].sort_values('ts').reset_index(drop=True)
+    # Clip de seguridad por límites de API
+    df = df[(df['ts'] >= start_dt) & (df['ts'] <= end_dt)].reset_index(drop=True)
+    return df

--- a/src/datalake/utils/__init__.py
+++ b/src/datalake/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility helpers for datalake."""

--- a/src/datalake/utils/symbols/__init__.py
+++ b/src/datalake/utils/symbols/__init__.py
@@ -1,0 +1,1 @@
+"""Symbol mapping utilities."""

--- a/src/datalake/utils/symbols/binance_map.py
+++ b/src/datalake/utils/symbols/binance_map.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+# Reglas simples de mapeo para Spot:
+#  - 'BTC-USD' -> 'BTCUSDT'
+#  - 'ETH-USD' -> 'ETHUSDT'
+#  - Si termina en '-USD', lo convertimos a 'USDT'.
+
+SPECIALS = {
+    'BTC-USD': 'BTCUSDT',
+    'ETH-USD': 'ETHUSDT',
+}
+
+def to_binance_symbol(symbol_logico: str) -> str:
+    s = (symbol_logico or '').upper().strip()
+    if s in SPECIALS:
+        return SPECIALS[s]
+    if '-' in s:
+        base, quote = s.split('-', 1)
+        # Para Spot usamos USDT por defecto cuando viene USD
+        if quote == 'USD':
+            quote = 'USDT'
+        return f"{base}{quote}"
+    # Si ya viene sin guión, se retorna tal cual
+    return s

--- a/tools/binance_fetch_tail.py
+++ b/tools/binance_fetch_tail.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+import argparse, os
+from datetime import datetime, timezone
+import pandas as pd
+from datalake.providers.binance.client import fetch_klines
+from datalake.utils.symbols.binance_map import to_binance_symbol
+
+UTC = timezone.utc
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--date', required=True, help='YYYY-MM-DD (UTC)')
+    ap.add_argument('--symbol', required=True, help='Símbolo lógico, p.ej. BTC-USD')
+    ap.add_argument('--region', choices=['global','us'], default='global')
+    ap.add_argument('--out', default=None)
+    args = ap.parse_args()
+
+    b_sym = to_binance_symbol(args.symbol)
+    D = datetime.strptime(args.date, '%Y-%m-%d').replace(tzinfo=UTC)
+    start = D.replace(hour=20, minute=0, second=0)
+    end   = D.replace(hour=23, minute=59, second=0)
+
+    df = fetch_klines(b_sym, start, end, tf='M1', region=args.region)
+    print(f"filas={len(df)} range={df['ts'].min() if not df.empty else None} -> {df['ts'].max() if not df.empty else None}")
+
+    if args.out:
+        os.makedirs(os.path.dirname(args.out), exist_ok=True)
+        df.to_csv(args.out, index=False)
+        print(f"CSV: {args.out}")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add standalone Binance client and ingest CLI for M1/M5 klines with idempotent lake writes
- map project symbols to Binance spot symbols
- document Binance ingestion and update dependencies for requests

## Testing
- `pip install -e .`
- `pytest -k binance -q`
- `python tools/binance_fetch_tail.py --date 2023-08-01 --symbol BTC-USD --region global` *(fails: ProxyError tunnel connection 403)*
- `python -m datalake.ingestors.binance.ingest_cli --help`


------
https://chatgpt.com/codex/tasks/task_e_68c72f2cff5c83249cb0b9f67c6a8631