### PR TITLE
Phase-4 | Binance pagination: cubrir 1440 velas/día (límite 1000 klines) con ventanas + merge idempotente

### DIFF
--- a/docs/README_BINANCE.md
+++ b/docs/README_BINANCE.md
@@ -28,3 +28,6 @@ python tools/binance_fetch_tail.py \
 - Timestamps tz-aware en UTC.
 - Dedupe/merge idéntico al de IB (clave: symbol, tf, ts, source).
 - Para Binance.US usar `--binance-region us`.
+
+### Límite de 1000 klines por request
+La ingesta pagina el rango diario en subventanas (p. ej., 00:00→16:39 y 16:40→23:59 para M1), mergea y deduplica por `ts`.

--- a/src/datalake/providers/binance/client.py
+++ b/src/datalake/providers/binance/client.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 import time
-import math
 from typing import Literal, Optional
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 import requests
 import pandas as pd
 
@@ -52,31 +51,70 @@ def fetch_klines(
         raise ValueError(f"Intervalo no soportado para Binance: {tf}")
     if start_dt.tzinfo is None or end_dt.tzinfo is None:
         raise ValueError("start_dt y end_dt deben ser tz-aware UTC")
+    if end_dt < start_dt:
+        return pd.DataFrame(columns=['ts','open','high','low','close','volume'])
+
+    step_minutes = 1 if tf == 'M1' else 5
+    max_bars = 1000  # límite de Binance por request
+    # Ventana máxima en minutos por request
+    max_minutes_per_req = max_bars * step_minutes
+
     base_url = BASE_URLS[region]
     url = f"{base_url}/api/v3/klines"
-    params = {
-        'symbol': symbol,
-        'interval': _INTERVALS[tf],
-        'startTime': _to_ms(start_dt),
-        'endTime': _to_ms(end_dt),
-        'limit': 1000
-    }
-    r = _rate_limited_get(url, params)
-    data = r.json()
-    if not isinstance(data, list):
-        raise BinanceHTTPError(f"Respuesta inesperada: {data}")
-    cols = [
-        'openTime','open','high','low','close','volume','closeTime',
-        'qav','numTrades','takerBuyBase','takerBuyQuote','ignore'
-    ]
-    df = pd.DataFrame(data, columns=cols)
-    if df.empty:
-        return df
-    df['ts'] = pd.to_datetime(df['openTime'], unit='ms', utc=True)
-    for c in ('open','high','low','close','volume'):
-        df[c] = pd.to_numeric(df[c], errors='coerce')
-    # Devolver sólo columnas del timeseries
-    df = df[['ts','open','high','low','close','volume']].sort_values('ts').reset_index(drop=True)
-    # Clip de seguridad por límites de API
-    df = df[(df['ts'] >= start_dt) & (df['ts'] <= end_dt)].reset_index(drop=True)
-    return df
+
+    out = []
+    cursor = start_dt
+    # Protección anti-bucle: máximo número de requests razonable por día
+    max_requests = 10
+    requests_done = 0
+
+    while cursor <= end_dt and requests_done < max_requests:
+        requests_done += 1
+        # Sub-ventana [cursor, win_end]
+        win_end = min(end_dt, cursor + timedelta(minutes=max_minutes_per_req - step_minutes))
+        # Número esperado de barras en esta sub-ventana
+        expected = int(((win_end - cursor).total_seconds() // 60) / step_minutes) + 1
+        params = {
+            'symbol': symbol,
+            'interval': _INTERVALS[tf],
+            'startTime': _to_ms(cursor),
+            'endTime': _to_ms(win_end),
+            'limit': min(max_bars, expected)
+        }
+        r = _rate_limited_get(url, params)
+        data = r.json()
+        if not isinstance(data, list):
+            raise BinanceHTTPError(f"Respuesta inesperada: {data}")
+
+        if not data:
+            # Si no hubo datos, avanzar la ventana para evitar estancarse
+            cursor = win_end + timedelta(minutes=step_minutes)
+            continue
+
+        cols = [
+            'openTime','open','high','low','close','volume','closeTime',
+            'qav','numTrades','takerBuyBase','takerBuyQuote','ignore'
+        ]
+        df = pd.DataFrame(data, columns=cols)
+        if df.empty:
+            cursor = win_end + timedelta(minutes=step_minutes)
+            continue
+
+        df['ts'] = pd.to_datetime(df['openTime'], unit='ms', utc=True)
+        for c in ('open','high','low','close','volume'):
+            df[c] = pd.to_numeric(df[c], errors='coerce')
+        df = df[['ts','open','high','low','close','volume']]
+        # Clip de seguridad (por si Binance devolvió de más)
+        df = df[(df['ts'] >= cursor) & (df['ts'] <= win_end)]
+        out.append(df)
+
+        # Avanzar cursor al siguiente minuto (o 5 min) después de win_end
+        cursor = win_end + timedelta(minutes=step_minutes)
+
+    if not out:
+        return pd.DataFrame(columns=['ts','open','high','low','close','volume'])
+
+    res = pd.concat(out, ignore_index=True).drop_duplicates(subset=['ts']).sort_values('ts').reset_index(drop=True)
+    # Clip final absoluto
+    res = res[(res['ts'] >= start_dt) & (res['ts'] <= end_dt)].reset_index(drop=True)
+    return res


### PR DESCRIPTION
## Summary
- paginate Binance klines to overcome 1000 bar API limit and avoid infinite loops
- update ingestion CLI to use paginated fetch and warn on row mismatches
- document 1000-klines limit and windowing approach

## Testing
- `pip install -e .`
- `pytest`
- ⚠️ `python -m datalake.ingestors.binance.ingest_cli --symbols BTC-USD --from 2023-08-01 --to 2023-08-01 --tf M1 --binance-region global` *(proxy error: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c736b2b48c8324b115ce6d1a86ab59