### PR TITLE
docs(specs): restore parquet schema specs (M1/M5/M15/M30) required by smoke tests

### DIFF
--- a/docs/specs/partitioning.md
+++ b/docs/specs/partitioning.md
@@ -1,0 +1,22 @@
+# Particionado del datalake
+
+El lake sigue la semántica `bar_end` en UTC y contratos de lectura en rangos **[from, to)**. Cada archivo Parquet respeta un
+particionado jerárquico que agrupa por **fuente**, **mercado**, **timeframe**, **símbolo** y fecha calendario.
+
+```
+data/
+  source={source}/
+    market=crypto/
+      timeframe={tf}/
+        symbol={symbol}/
+          year={YYYY}/
+            month={MM}/
+              part-{YYYY}-{MM}.parquet
+```
+
+## Convenciones
+- `tf` utiliza códigos tipo `M1`, `M5`, `M15`, `M30`, etc.
+- Los timestamps (`ts`) representan el final de la vela (`bar_end`) y están en UTC.
+- La lectura siempre debe pedirse con rangos half-open: `from <= ts < to`.
+- Las particiones no se solapan: cada archivo contiene valores de `ts` estrictamente crecientes.
+- Cualquier dataset derivado (por ejemplo niveles diarios) reutiliza el mismo árbol añadiendo particiones específicas, como `level={level}`.

--- a/docs/specs/schema_levels_daily.parquet.json
+++ b/docs/specs/schema_levels_daily.parquet.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "version": 1,
+  "dataset": "crypto.levels",
+  "timeframe": "D1",
+  "description": "Niveles diarios derivados de OHLCV en UTC con semántica bar_end y contrato de lectura [from, to).",
+  "layout": "data/source={source}/market=crypto/timeframe={tf}/symbol={symbol}/level={level}/year={YYYY}/month={MM}/part-{YYYY}-{MM}.parquet",
+  "ts_semantics": "bar_end",
+  "range_contract": "[from, to) en UTC",
+  "properties": {
+    "ts": {
+      "dtype": "timestamp[ns, tz=UTC]",
+      "nullable": false,
+      "description": "UTC bar_end del día para el que aplica el nivel."
+    },
+    "level": {
+      "dtype": "string",
+      "nullable": false,
+      "description": "Nombre del nivel (ej. previous_high, previous_low, pivot)."
+    },
+    "value": {
+      "dtype": "float64",
+      "nullable": false,
+      "description": "Valor numérico del nivel."
+    },
+    "symbol": {
+      "dtype": "string",
+      "nullable": false,
+      "description": "Símbolo normalizado (por ejemplo BTC-USD)."
+    },
+    "source": {
+      "dtype": "string",
+      "nullable": false,
+      "description": "Proveedor o pipeline que calculó el nivel."
+    },
+    "exchange": {
+      "dtype": "string",
+      "nullable": false,
+      "description": "Exchange fuente de los datos base."
+    },
+    "tf_origin": {
+      "dtype": "string",
+      "nullable": false,
+      "description": "Timeframe base usado para el cálculo (ej. M1)."
+    },
+    "metadata": {
+      "dtype": "struct",
+      "nullable": true,
+      "description": "Metadatos opcionales serializados (por ejemplo método de cálculo)."
+    }
+  },
+  "required": ["ts", "level", "value", "symbol", "source", "exchange", "tf_origin"],
+  "ordering": ["ts", "level"],
+  "primary_key": ["source", "symbol", "level", "ts"],
+  "dedupe_on": ["source", "symbol", "level", "ts"]
+}

--- a/docs/specs/schema_m1.parquet.json
+++ b/docs/specs/schema_m1.parquet.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "version": 1,
+  "dataset": "crypto.candles",
+  "timeframe": "M1",
+  "description": "Esquema canónico de velas M1. Timestamps en UTC al cierre de vela (bar_end). Contrato de lectura [from, to).",
+  "layout": "data/source={source}/market=crypto/timeframe={tf}/symbol={symbol}/year={YYYY}/month={MM}/part-{YYYY}-{MM}.parquet",
+  "ts_semantics": "bar_end",
+  "range_contract": "[from, to) en UTC",
+  "properties": {
+    "ts": {
+      "dtype": "timestamp[ns, tz=UTC]",
+      "nullable": false,
+      "description": "UTC bar_end de la vela de 1 minuto (ts marca el final del intervalo)."
+    },
+    "open": {
+      "dtype": "float64",
+      "nullable": false,
+      "description": "Precio de apertura del minuto."
+    },
+    "high": {
+      "dtype": "float64",
+      "nullable": false,
+      "description": "Precio máximo del minuto."
+    },
+    "low": {
+      "dtype": "float64",
+      "nullable": false,
+      "description": "Precio mínimo del minuto."
+    },
+    "close": {
+      "dtype": "float64",
+      "nullable": false,
+      "description": "Precio de cierre del minuto."
+    },
+    "volume": {
+      "dtype": "float64",
+      "nullable": true,
+      "description": "Volumen negociado durante el minuto (cuando la fuente lo provee)."
+    },
+    "symbol": {
+      "dtype": "string",
+      "nullable": false,
+      "description": "Símbolo de trading normalizado (por ejemplo BTC-USD)."
+    },
+    "tf": {
+      "dtype": "string",
+      "nullable": false,
+      "description": "Timeframe declarado en el archivo (M1)."
+    },
+    "source": {
+      "dtype": "string",
+      "nullable": false,
+      "description": "Proveedor de datos o colector (por ejemplo binance)."
+    },
+    "exchange": {
+      "dtype": "string",
+      "nullable": false,
+      "description": "Exchange original de la data."
+    }
+  },
+  "required": ["ts", "open", "high", "low", "close", "symbol", "tf", "source", "exchange"],
+  "ordering": ["ts"],
+  "primary_key": ["source", "symbol", "tf", "ts"],
+  "dedupe_on": ["source", "symbol", "tf", "ts"],
+  "examples": {
+    "head": {
+      "ts": "2025-08-01T00:00:00Z",
+      "open": 115764.07,
+      "high": 115764.08,
+      "low": 115704.78,
+      "close": 115729.00,
+      "volume": 11.87539,
+      "symbol": "BTC-USD",
+      "tf": "M1",
+      "source": "binance",
+      "exchange": "BINANCE"
+    }
+  }
+}

--- a/docs/specs/schema_m15.parquet.json
+++ b/docs/specs/schema_m15.parquet.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "version": 1,
+  "dataset": "crypto.candles",
+  "timeframe": "M15",
+  "description": "Esquema canónico de velas M15. UTC bar_end, contrato [from, to).",
+  "layout": "data/source={source}/market=crypto/timeframe={tf}/symbol={symbol}/year={YYYY}/month={MM}/part-{YYYY}-{MM}.parquet",
+  "ts_semantics": "bar_end",
+  "range_contract": "[from, to) en UTC",
+  "properties": {
+    "ts": {
+      "dtype": "timestamp[ns, tz=UTC]",
+      "nullable": false,
+      "description": "UTC bar_end de la vela de 15 minutos (ts marca el final del intervalo)."
+    },
+    "open": { "dtype": "float64", "nullable": false },
+    "high": { "dtype": "float64", "nullable": false },
+    "low": { "dtype": "float64", "nullable": false },
+    "close": { "dtype": "float64", "nullable": false },
+    "volume": { "dtype": "float64", "nullable": true },
+    "symbol": { "dtype": "string", "nullable": false },
+    "tf": { "dtype": "string", "nullable": false },
+    "source": { "dtype": "string", "nullable": false },
+    "exchange": { "dtype": "string", "nullable": false }
+  },
+  "required": ["ts", "open", "high", "low", "close", "symbol", "tf", "source", "exchange"],
+  "ordering": ["ts"],
+  "primary_key": ["source", "symbol", "tf", "ts"],
+  "dedupe_on": ["source", "symbol", "tf", "ts"]
+}

--- a/docs/specs/schema_m30.parquet.json
+++ b/docs/specs/schema_m30.parquet.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "version": 1,
+  "dataset": "crypto.candles",
+  "timeframe": "M30",
+  "description": "Esquema canónico de velas M30. UTC bar_end, contrato [from, to).",
+  "layout": "data/source={source}/market=crypto/timeframe={tf}/symbol={symbol}/year={YYYY}/month={MM}/part-{YYYY}-{MM}.parquet",
+  "ts_semantics": "bar_end",
+  "range_contract": "[from, to) en UTC",
+  "properties": {
+    "ts": {
+      "dtype": "timestamp[ns, tz=UTC]",
+      "nullable": false,
+      "description": "UTC bar_end de la vela de 30 minutos (ts marca el final del intervalo)."
+    },
+    "open": { "dtype": "float64", "nullable": false },
+    "high": { "dtype": "float64", "nullable": false },
+    "low": { "dtype": "float64", "nullable": false },
+    "close": { "dtype": "float64", "nullable": false },
+    "volume": { "dtype": "float64", "nullable": true },
+    "symbol": { "dtype": "string", "nullable": false },
+    "tf": { "dtype": "string", "nullable": false },
+    "source": { "dtype": "string", "nullable": false },
+    "exchange": { "dtype": "string", "nullable": false }
+  },
+  "required": ["ts", "open", "high", "low", "close", "symbol", "tf", "source", "exchange"],
+  "ordering": ["ts"],
+  "primary_key": ["source", "symbol", "tf", "ts"],
+  "dedupe_on": ["source", "symbol", "tf", "ts"]
+}

--- a/docs/specs/schema_m5.parquet.json
+++ b/docs/specs/schema_m5.parquet.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "version": 1,
+  "dataset": "crypto.candles",
+  "timeframe": "M5",
+  "description": "Esquema canónico de velas M5 (mismas columnas que M1). UTC bar_end, contrato [from, to).",
+  "layout": "data/source={source}/market=crypto/timeframe={tf}/symbol={symbol}/year={YYYY}/month={MM}/part-{YYYY}-{MM}.parquet",
+  "ts_semantics": "bar_end",
+  "range_contract": "[from, to) en UTC",
+  "properties": {
+    "ts": {
+      "dtype": "timestamp[ns, tz=UTC]",
+      "nullable": false,
+      "description": "UTC bar_end de la vela de 5 minutos (ts marca el final del intervalo)."
+    },
+    "open": { "dtype": "float64", "nullable": false },
+    "high": { "dtype": "float64", "nullable": false },
+    "low": { "dtype": "float64", "nullable": false },
+    "close": { "dtype": "float64", "nullable": false },
+    "volume": { "dtype": "float64", "nullable": true },
+    "symbol": { "dtype": "string", "nullable": false },
+    "tf": { "dtype": "string", "nullable": false },
+    "source": { "dtype": "string", "nullable": false },
+    "exchange": { "dtype": "string", "nullable": false }
+  },
+  "required": ["ts", "open", "high", "low", "close", "symbol", "tf", "source", "exchange"],
+  "ordering": ["ts"],
+  "primary_key": ["source", "symbol", "tf", "ts"],
+  "dedupe_on": ["source", "symbol", "tf", "ts"]
+}


### PR DESCRIPTION
## Summary
- add parquet schema specs for minute candles (M1/M5/M15/M30) aligned with UTC bar_end semantics and half-open contracts
- document daily level schema with consistent layout and metadata fields
- capture the shared partitioning strategy for the datalake in dedicated documentation

## Testing
- pytest -q tests/test_specs_smoke.py


------
https://chatgpt.com/codex/tasks/task_e_68ca1ecabce08324b7ef5bfa1089a47a